### PR TITLE
feat: withdrawal token

### DIFF
--- a/src/WithdrawalToken.sol
+++ b/src/WithdrawalToken.sol
@@ -60,12 +60,12 @@ contract WithdrawalToken is
     }
 
     function mintBatch(
-        address to,
-        uint256[] calldata ids,
-        uint256[] calldata amounts,
-        bytes calldata data
-    ) external onlyOwner {
-        _mintBatch(to, ids, amounts, data);
+        address,
+        uint256[] calldata,
+        uint256[] calldata,
+        bytes calldata
+    ) external pure {
+        revert("mintBatch is disabled");
     }
 
     function burn(address from, uint256 id, uint256 amount) public override {
@@ -74,12 +74,11 @@ contract WithdrawalToken is
     }
 
     function burnBatch(
-        address from,
-        uint256[] memory ids,
-        uint256[] memory amounts
-    ) public override {
-        // Only owner or approved can burn
-        super.burnBatch(from, ids, amounts);
+        address,
+        uint256[] memory,
+        uint256[] memory
+    ) public pure override {
+        revert("burnBatch is disabled");
     }
 
     error InvalidImplementation();

--- a/src/WithdrawalToken.sol
+++ b/src/WithdrawalToken.sol
@@ -102,6 +102,10 @@ contract WithdrawalToken is
         _burn(from, id, amount);
     }
 
+    function updateCoreAddress(address newCore) external onlyOwner {
+        _setCoreAddress(newCore);
+    }
+
     /// @inheritdoc UUPSUpgradeable
     function _authorizeUpgrade(
         address

--- a/src/WithdrawalToken.sol
+++ b/src/WithdrawalToken.sol
@@ -22,6 +22,8 @@ contract WithdrawalToken is
     OwnableUpgradeable,
     UUPSUpgradeable
 {
+    event CoreUpdated(address indexed updater, address newCore);
+
     /// @dev keccak256(abi.encode(uint256(keccak256("maxbtc.withdrawal_token.name")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant NAME_STORAGE_SLOT =
         0x190eb2605c587c583d04f046ca87c4680dfd9f551aa34f413199ca360f03b400;
@@ -104,6 +106,7 @@ contract WithdrawalToken is
 
     function updateCoreAddress(address newCore) external onlyOwner {
         _setCoreAddress(newCore);
+        emit CoreUpdated(msg.sender, newCore);
     }
 
     /// @inheritdoc UUPSUpgradeable

--- a/src/WithdrawalToken.sol
+++ b/src/WithdrawalToken.sol
@@ -22,7 +22,6 @@ import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 contract WithdrawalToken is
     Initializable,
     ERC1155Upgradeable,
-    ERC1155BurnableUpgradeable,
     OwnableUpgradeable,
     UUPSUpgradeable
 {
@@ -57,7 +56,7 @@ contract WithdrawalToken is
     }
 
     function symbol(uint256 id) public pure returns (string memory) {
-        return string(abi.encodePacked("WRT-", id.toString()));
+        return string.concat("WRT-", id.toString());
     }
 
     function mint(
@@ -69,31 +68,9 @@ contract WithdrawalToken is
         _mint(to, id, amount, data);
     }
 
-    function mintBatch(
-        address,
-        uint256[] calldata,
-        uint256[] calldata,
-        bytes calldata
-    ) external pure {
-        revert("mintBatch is disabled");
-    }
-
-    function burn(
-        address from,
-        uint256 id,
-        uint256 amount
-    ) public override onlyOwner {
+    function burn(address from, uint256 id, uint256 amount) public onlyOwner {
         _burn(from, id, amount);
     }
-
-    function burnBatch(
-        address,
-        uint256[] memory,
-        uint256[] memory
-    ) public pure override {
-        revert("burnBatch is disabled");
-    }
-
     error InvalidImplementation();
 
     /// @inheritdoc UUPSUpgradeable
@@ -101,6 +78,4 @@ contract WithdrawalToken is
         address
     ) internal view override(UUPSUpgradeable) onlyOwner {}
     // solhint-disable-previous-line no-empty-blocks
-
-    uint256[50] private __gap;
 }

--- a/src/WithdrawalToken.sol
+++ b/src/WithdrawalToken.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {
+    ERC1155Upgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
+import {
+    ERC1155BurnableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155BurnableUpgradeable.sol";
+import {
+    OwnableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {
+    Initializable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {
+    UUPSUpgradeable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+contract WithdrawalToken is
+    Initializable,
+    ERC1155Upgradeable,
+    ERC1155BurnableUpgradeable,
+    OwnableUpgradeable,
+    UUPSUpgradeable
+{
+    using Strings for uint256;
+
+    string public name;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address owner_,
+        string memory baseUri_,
+        string memory name_
+    ) public initializer {
+        __ERC1155_init(baseUri_);
+        __Ownable_init(owner_);
+        __UUPSUpgradeable_init();
+
+        name = name_;
+    }
+
+    function symbol(uint256 id) public pure returns (string memory) {
+        return string(abi.encodePacked("WRT-", id.toString()));
+    }
+
+    function mint(
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) external onlyOwner {
+        _mint(to, id, amount, data);
+    }
+
+    function mintBatch(
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) external onlyOwner {
+        _mintBatch(to, ids, amounts, data);
+    }
+
+    function burn(address from, uint256 id, uint256 amount) public override {
+        // Only owner or approved can burn
+        super.burn(from, id, amount);
+    }
+
+    function burnBatch(
+        address from,
+        uint256[] memory ids,
+        uint256[] memory amounts
+    ) public override {
+        // Only owner or approved can burn
+        super.burnBatch(from, ids, amounts);
+    }
+
+    error InvalidImplementation();
+
+    /// @inheritdoc UUPSUpgradeable
+    function _authorizeUpgrade(
+        address
+    ) internal view override(UUPSUpgradeable) onlyOwner {}
+    // solhint-disable-previous-line no-empty-blocks
+
+    uint256[50] private __gap;
+}

--- a/src/WithdrawalToken.sol
+++ b/src/WithdrawalToken.sol
@@ -39,7 +39,7 @@ contract WithdrawalToken is
     error OnlyCoreCanMintOrBurn();
 
     modifier onlyCore() {
-        require(msg.sender == coreAddress(), OnlyCoreCanMintOrBurn());
+        require(_msgSender() == coreAddress(), OnlyCoreCanMintOrBurn());
         _;
     }
 
@@ -100,7 +100,7 @@ contract WithdrawalToken is
         _mint(to, id, amount, data);
     }
 
-    function burn(address from, uint256 id, uint256 amount) public onlyCore {
+    function burn(address from, uint256 id, uint256 amount) public {
         _burn(from, id, amount);
     }
 

--- a/src/WithdrawalToken.sol
+++ b/src/WithdrawalToken.sol
@@ -36,10 +36,10 @@ contract WithdrawalToken is
 
     using Strings for uint256;
 
-    error OnlyCoreCanMintOrBurn();
+    error OnlyCoreCanMint();
 
     modifier onlyCore() {
-        require(_msgSender() == coreAddress(), OnlyCoreCanMintOrBurn());
+        require(_msgSender() == coreAddress(), OnlyCoreCanMint());
         _;
     }
 

--- a/test/WithdrawalToken.test.sol
+++ b/test/WithdrawalToken.test.sol
@@ -16,7 +16,7 @@ contract WithdrawalTokenTest is Test {
         WithdrawalToken implementation = new WithdrawalToken();
         bytes memory initData = abi.encodeCall(
             WithdrawalToken.initialize,
-            (owner, "https://api.example.com/", "WithdrawalToken")
+            (owner, "https://api.example.com/", "WithdrawalToken", "WRT-")
         );
         ERC1967Proxy proxy = new ERC1967Proxy(
             address(implementation),

--- a/test/WithdrawalToken.test.sol
+++ b/test/WithdrawalToken.test.sol
@@ -37,18 +37,6 @@ contract WithdrawalTokenTest is Test {
         assertEq(token.balanceOf(user, 1), 100);
     }
 
-    function testMintBatchByOwnerReverts() public {
-        uint256[] memory ids = new uint256[](2);
-        uint256[] memory amounts = new uint256[](2);
-        ids[0] = 1;
-        ids[1] = 2;
-        amounts[0] = 50;
-        amounts[1] = 150;
-        vm.prank(owner);
-        vm.expectRevert(bytes("mintBatch is disabled"));
-        token.mintBatch(user, ids, amounts, "");
-    }
-
     function testMintNotOwnerReverts() public {
         vm.expectRevert(
             abi.encodeWithSignature(
@@ -59,14 +47,6 @@ contract WithdrawalTokenTest is Test {
         token.mint(user, 1, 1, "");
     }
 
-    function testMintBatchNotOwnerReverts() public {
-        uint256[] memory ids = new uint256[](1);
-        uint256[] memory amounts = new uint256[](1);
-        ids[0] = 1;
-        amounts[0] = 1;
-        vm.expectRevert(bytes("mintBatch is disabled"));
-        token.mintBatch(user, ids, amounts, "");
-    }
     function testBurnByOwner() public {
         vm.prank(owner);
         token.mint(user, 1, 100, "");
@@ -75,19 +55,6 @@ contract WithdrawalTokenTest is Test {
         vm.prank(owner);
         token.burn(user, 1, 40);
         assertEq(token.balanceOf(user, 1), 60);
-    }
-
-    function testBurnBatchByOwnerReverts() public {
-        uint256[] memory ids = new uint256[](2);
-        uint256[] memory amounts = new uint256[](2);
-        ids[0] = 1;
-        ids[1] = 2;
-        amounts[0] = 50;
-        amounts[1] = 150;
-        vm.prank(owner);
-        vm.expectRevert(bytes("mintBatch is disabled"));
-        token.mintBatch(user, ids, amounts, "");
-        // burnBatch cannot be tested for revert if mintBatch is disabled
     }
 
     function testBurnNotOwnerReverts() public {
@@ -102,18 +69,5 @@ contract WithdrawalTokenTest is Test {
             )
         );
         token.burn(user, 1, 10);
-    }
-
-    function testBurnBatchNotOwnerOrApprovedReverts() public {
-        uint256[] memory ids = new uint256[](2);
-        uint256[] memory amounts = new uint256[](2);
-        ids[0] = 1;
-        ids[1] = 2;
-        amounts[0] = 50;
-        amounts[1] = 150;
-        vm.prank(owner);
-        vm.expectRevert(bytes("mintBatch is disabled"));
-        token.mintBatch(user, ids, amounts, "");
-        // burnBatch cannot be tested for revert if mintBatch is disabled
     }
 }

--- a/test/WithdrawalToken.test.sol
+++ b/test/WithdrawalToken.test.sol
@@ -71,7 +71,8 @@ contract WithdrawalTokenTest is Test {
         vm.prank(owner);
         token.mint(user, 1, 100, "");
         assertEq(token.balanceOf(user, 1), 100);
-        vm.prank(user);
+        // Only owner can burn
+        vm.prank(owner);
         token.burn(user, 1, 40);
         assertEq(token.balanceOf(user, 1), 60);
     }
@@ -89,12 +90,17 @@ contract WithdrawalTokenTest is Test {
         // burnBatch cannot be tested for revert if mintBatch is disabled
     }
 
-    function testBurnNotOwnerOrApprovedReverts() public {
+    function testBurnNotOwnerReverts() public {
         vm.prank(owner);
         token.mint(user, 1, 100, "");
         address attacker = address(0xBEEF);
         vm.prank(attacker);
-        vm.expectRevert();
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "OwnableUnauthorizedAccount(address)",
+                attacker
+            )
+        );
         token.burn(user, 1, 10);
     }
 

--- a/test/WithdrawalToken.test.sol
+++ b/test/WithdrawalToken.test.sol
@@ -11,6 +11,7 @@ contract WithdrawalTokenTest is Test {
     WithdrawalToken internal token;
     address internal owner = address(0xABCD);
     address internal core = address(0xBEEF);
+    error OwnableUnauthorizedAccount(address account);
     address internal user = address(0x1234);
 
     function setUp() public {
@@ -59,5 +60,23 @@ contract WithdrawalTokenTest is Test {
         vm.prank(user);
         vm.expectRevert(WithdrawalToken.OnlyCoreCanMintOrBurn.selector);
         token.burn(user, 1, 10);
+    }
+
+    function testUpdateCoreAddressByOwner() public {
+        address newCore = address(0xDEAD);
+        vm.prank(owner);
+        token.updateCoreAddress(newCore);
+        assertEq(token.coreAddress(), newCore);
+    }
+
+    function testUpdateCoreAddressNotOwnerReverts() public {
+        address newCore = address(0xDEAD);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OwnableUnauthorizedAccount.selector,
+                address(this)
+            )
+        );
+        token.updateCoreAddress(newCore);
     }
 }

--- a/test/WithdrawalToken.test.sol
+++ b/test/WithdrawalToken.test.sol
@@ -37,7 +37,7 @@ contract WithdrawalTokenTest is Test {
         assertEq(token.balanceOf(user, 1), 100);
     }
 
-    function testMintBatchByOwner() public {
+    function testMintBatchByOwnerReverts() public {
         uint256[] memory ids = new uint256[](2);
         uint256[] memory amounts = new uint256[](2);
         ids[0] = 1;
@@ -45,9 +45,8 @@ contract WithdrawalTokenTest is Test {
         amounts[0] = 50;
         amounts[1] = 150;
         vm.prank(owner);
+        vm.expectRevert(bytes("mintBatch is disabled"));
         token.mintBatch(user, ids, amounts, "");
-        assertEq(token.balanceOf(user, 1), 50);
-        assertEq(token.balanceOf(user, 2), 150);
     }
 
     function testMintNotOwnerReverts() public {
@@ -65,12 +64,7 @@ contract WithdrawalTokenTest is Test {
         uint256[] memory amounts = new uint256[](1);
         ids[0] = 1;
         amounts[0] = 1;
-        vm.expectRevert(
-            abi.encodeWithSignature(
-                "OwnableUnauthorizedAccount(address)",
-                address(this)
-            )
-        );
+        vm.expectRevert(bytes("mintBatch is disabled"));
         token.mintBatch(user, ids, amounts, "");
     }
     function testBurnByOwner() public {
@@ -82,7 +76,7 @@ contract WithdrawalTokenTest is Test {
         assertEq(token.balanceOf(user, 1), 60);
     }
 
-    function testBurnBatchByOwner() public {
+    function testBurnBatchByOwnerReverts() public {
         uint256[] memory ids = new uint256[](2);
         uint256[] memory amounts = new uint256[](2);
         ids[0] = 1;
@@ -90,16 +84,9 @@ contract WithdrawalTokenTest is Test {
         amounts[0] = 50;
         amounts[1] = 150;
         vm.prank(owner);
+        vm.expectRevert(bytes("mintBatch is disabled"));
         token.mintBatch(user, ids, amounts, "");
-        assertEq(token.balanceOf(user, 1), 50);
-        assertEq(token.balanceOf(user, 2), 150);
-        uint256[] memory burnAmounts = new uint256[](2);
-        burnAmounts[0] = 10;
-        burnAmounts[1] = 100;
-        vm.prank(user);
-        token.burnBatch(user, ids, burnAmounts);
-        assertEq(token.balanceOf(user, 1), 40);
-        assertEq(token.balanceOf(user, 2), 50);
+        // burnBatch cannot be tested for revert if mintBatch is disabled
     }
 
     function testBurnNotOwnerOrApprovedReverts() public {
@@ -119,13 +106,8 @@ contract WithdrawalTokenTest is Test {
         amounts[0] = 50;
         amounts[1] = 150;
         vm.prank(owner);
+        vm.expectRevert(bytes("mintBatch is disabled"));
         token.mintBatch(user, ids, amounts, "");
-        address attacker = address(0xBEEF);
-        uint256[] memory burnAmounts = new uint256[](2);
-        burnAmounts[0] = 10;
-        burnAmounts[1] = 100;
-        vm.prank(attacker);
-        vm.expectRevert();
-        token.burnBatch(user, ids, burnAmounts);
+        // burnBatch cannot be tested for revert if mintBatch is disabled
     }
 }

--- a/test/WithdrawalToken.test.sol
+++ b/test/WithdrawalToken.test.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {WithdrawalToken} from "../src/WithdrawalToken.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract WithdrawalTokenTest is Test {
+    WithdrawalToken internal token;
+    address internal owner = address(0xABCD);
+    address internal user = address(0x1234);
+
+    function setUp() public {
+        WithdrawalToken implementation = new WithdrawalToken();
+        bytes memory initData = abi.encodeCall(
+            WithdrawalToken.initialize,
+            (owner, "https://api.example.com/", "WithdrawalToken")
+        );
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(implementation),
+            initData
+        );
+        token = WithdrawalToken(address(proxy));
+        // Ownership is set to `owner` in initialize, so we need to prank as owner for owner-only functions
+    }
+
+    function testNameAndSymbol() public view {
+        assertEq(token.name(), "WithdrawalToken");
+        assertEq(token.symbol(1), "WRT-1");
+    }
+
+    function testMintByOwner() public {
+        vm.prank(owner);
+        token.mint(user, 1, 100, "");
+        assertEq(token.balanceOf(user, 1), 100);
+    }
+
+    function testMintBatchByOwner() public {
+        uint256[] memory ids = new uint256[](2);
+        uint256[] memory amounts = new uint256[](2);
+        ids[0] = 1;
+        ids[1] = 2;
+        amounts[0] = 50;
+        amounts[1] = 150;
+        vm.prank(owner);
+        token.mintBatch(user, ids, amounts, "");
+        assertEq(token.balanceOf(user, 1), 50);
+        assertEq(token.balanceOf(user, 2), 150);
+    }
+
+    function testMintNotOwnerReverts() public {
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "OwnableUnauthorizedAccount(address)",
+                address(this)
+            )
+        );
+        token.mint(user, 1, 1, "");
+    }
+
+    function testMintBatchNotOwnerReverts() public {
+        uint256[] memory ids = new uint256[](1);
+        uint256[] memory amounts = new uint256[](1);
+        ids[0] = 1;
+        amounts[0] = 1;
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "OwnableUnauthorizedAccount(address)",
+                address(this)
+            )
+        );
+        token.mintBatch(user, ids, amounts, "");
+    }
+    function testBurnByOwner() public {
+        vm.prank(owner);
+        token.mint(user, 1, 100, "");
+        assertEq(token.balanceOf(user, 1), 100);
+        vm.prank(user);
+        token.burn(user, 1, 40);
+        assertEq(token.balanceOf(user, 1), 60);
+    }
+
+    function testBurnBatchByOwner() public {
+        uint256[] memory ids = new uint256[](2);
+        uint256[] memory amounts = new uint256[](2);
+        ids[0] = 1;
+        ids[1] = 2;
+        amounts[0] = 50;
+        amounts[1] = 150;
+        vm.prank(owner);
+        token.mintBatch(user, ids, amounts, "");
+        assertEq(token.balanceOf(user, 1), 50);
+        assertEq(token.balanceOf(user, 2), 150);
+        uint256[] memory burnAmounts = new uint256[](2);
+        burnAmounts[0] = 10;
+        burnAmounts[1] = 100;
+        vm.prank(user);
+        token.burnBatch(user, ids, burnAmounts);
+        assertEq(token.balanceOf(user, 1), 40);
+        assertEq(token.balanceOf(user, 2), 50);
+    }
+
+    function testBurnNotOwnerOrApprovedReverts() public {
+        vm.prank(owner);
+        token.mint(user, 1, 100, "");
+        address attacker = address(0xBEEF);
+        vm.prank(attacker);
+        vm.expectRevert();
+        token.burn(user, 1, 10);
+    }
+
+    function testBurnBatchNotOwnerOrApprovedReverts() public {
+        uint256[] memory ids = new uint256[](2);
+        uint256[] memory amounts = new uint256[](2);
+        ids[0] = 1;
+        ids[1] = 2;
+        amounts[0] = 50;
+        amounts[1] = 150;
+        vm.prank(owner);
+        token.mintBatch(user, ids, amounts, "");
+        address attacker = address(0xBEEF);
+        uint256[] memory burnAmounts = new uint256[](2);
+        burnAmounts[0] = 10;
+        burnAmounts[1] = 100;
+        vm.prank(attacker);
+        vm.expectRevert();
+        token.burnBatch(user, ids, burnAmounts);
+    }
+}

--- a/test/WithdrawalToken.test.sol
+++ b/test/WithdrawalToken.test.sol
@@ -44,22 +44,14 @@ contract WithdrawalTokenTest is Test {
         token.mint(user, 1, 1, "");
     }
 
-    function testBurnByCore() public {
+    function testBurn() public {
         vm.prank(core);
         token.mint(user, 1, 100, "");
         assertEq(token.balanceOf(user, 1), 100);
-        // Only core can burn
-        vm.prank(core);
+        // Anyone can burn
+        vm.prank(user);
         token.burn(user, 1, 40);
         assertEq(token.balanceOf(user, 1), 60);
-    }
-
-    function testBurnNotCoreReverts() public {
-        vm.prank(core);
-        token.mint(user, 1, 100, "");
-        vm.prank(user);
-        vm.expectRevert(WithdrawalToken.OnlyCoreCanMintOrBurn.selector);
-        token.burn(user, 1, 10);
     }
 
     function testUpdateCoreAddressByOwner() public {

--- a/test/WithdrawalToken.test.sol
+++ b/test/WithdrawalToken.test.sol
@@ -40,7 +40,7 @@ contract WithdrawalTokenTest is Test {
     }
 
     function testMintNotCoreReverts() public {
-        vm.expectRevert(WithdrawalToken.OnlyCoreCanMintOrBurn.selector);
+        vm.expectRevert(WithdrawalToken.OnlyCoreCanMint.selector);
         token.mint(user, 1, 1, "");
     }
 


### PR DESCRIPTION
This pull request introduces a new upgradeable ERC1155 token contract called `WithdrawalToken`, along with the tests. The contract supports minting and burning of tokens, is ownable, and is designed for upgradeability using the UUPS proxy pattern. The accompanying tests validate the core functionality and access controls.