### PR TITLE
fix: restrict changing core contract in withdrawal manager

### DIFF
--- a/src/WithdrawalManager.sol
+++ b/src/WithdrawalManager.sol
@@ -1,13 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
-import {ERC1155HolderUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC1155/utils/ERC1155HolderUpgradeable.sol";
+import {
+    Initializable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {
+    UUPSUpgradeable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {
+    Ownable2StepUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {
+    ERC1155HolderUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC1155/utils/ERC1155HolderUpgradeable.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {
+    SafeERC20
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import {Batch} from "./types/CoreTypes.sol";
 import {WithdrawalToken} from "./WithdrawalToken.sol";
@@ -133,16 +143,13 @@ contract WithdrawalManager is
     }
 
     function updateConfig(
-        address newCoreContract,
         address newWbtcContract,
         address newWithdrawalTokenContract
     ) external onlyOwner {
         WithdrawalManagerConfig storage config = _getWithdrawalManagerConfig();
-        if (newCoreContract == address(0)) revert InvalidCoreContractAddress();
         if (newWbtcContract == address(0)) revert InvalidwBTCContractAddress();
         if (newWithdrawalTokenContract == address(0))
             revert InvalidWithdrawalTokenContractAddress();
-        config.coreContract = newCoreContract;
         config.wbtcContract = newWbtcContract;
         config.withdrawalTokenContract = newWithdrawalTokenContract;
         emit ConfigUpdated(config);

--- a/test/MaxBTCCoreIntegration.test.sol
+++ b/test/MaxBTCCoreIntegration.test.sol
@@ -3,8 +3,12 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    SafeERC20
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {MaxBTCCore} from "../src/MaxBTCCore.sol";
 import {MaxBTCERC20} from "../src/MaxBTCERC20.sol";
@@ -177,12 +181,7 @@ contract MaxBTCCoreIntegrationTest is Test {
         waitosaurHolder.updateConfig(address(manager));
 
         // Now initialize dependent contracts with the finalized core address.
-        maxbtc.initialize(
-            address(this),
-            address(this),
-            "maxBTC",
-            "maxBTC"
-        );
+        maxbtc.initialize(address(this), address(this), "maxBTC", "maxBTC");
         maxbtc.initializeV2(address(core));
         withdrawalToken.initialize(
             address(this),
@@ -213,11 +212,7 @@ contract MaxBTCCoreIntegrationTest is Test {
 
         // Manager needs to know core for finalized batch lookups
         vm.prank(address(this));
-        manager.updateConfig(
-            address(core),
-            address(wbtc),
-            address(withdrawalToken)
-        );
+        manager.updateConfig(address(wbtc), address(withdrawalToken));
     }
 
     function testIntegrationDepositWithdrawRedeem() external {

--- a/test/WithdrawalManager.test.sol
+++ b/test/WithdrawalManager.test.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import {WithdrawalManager, ICoreContract} from "../src/WithdrawalManager.sol";
 import {WithdrawalToken} from "../src/WithdrawalToken.sol";
@@ -284,16 +286,14 @@ contract WithdrawalManagerTest is Test {
 
     function testUpdateConfigByOwner() public {
         // Owner updates config successfully
-        address newCore = address(0x1111);
         address newWbtc = address(0x2222);
         address newToken = address(0x3333);
 
         vm.prank(owner);
-        manager.updateConfig(newCore, newWbtc, newToken);
+        manager.updateConfig(newWbtc, newToken);
 
         WithdrawalManager.WithdrawalManagerConfig memory config = manager
             .getConfig();
-        assertEq(config.coreContract, newCore);
         assertEq(config.wbtcContract, newWbtc);
         assertEq(config.withdrawalTokenContract, newToken);
     }
@@ -306,7 +306,7 @@ contract WithdrawalManagerTest is Test {
                 address(this)
             )
         );
-        manager.updateConfig(address(1), address(2), address(3));
+        manager.updateConfig(address(1), address(2));
     }
 
     function testUpdateConfigRevertsForZeroAddresses() public {
@@ -315,18 +315,10 @@ contract WithdrawalManagerTest is Test {
         vm.prank(owner);
         vm.expectRevert(
             abi.encodeWithSelector(
-                WithdrawalManager.InvalidCoreContractAddress.selector
-            )
-        );
-        manager.updateConfig(address(0), address(2), address(3));
-
-        vm.prank(owner);
-        vm.expectRevert(
-            abi.encodeWithSelector(
                 WithdrawalManager.InvalidwBTCContractAddress.selector
             )
         );
-        manager.updateConfig(address(1), address(0), address(3));
+        manager.updateConfig(address(0), address(1));
 
         vm.prank(owner);
         vm.expectRevert(
@@ -334,7 +326,7 @@ contract WithdrawalManagerTest is Test {
                 WithdrawalManager.InvalidWithdrawalTokenContractAddress.selector
             )
         );
-        manager.updateConfig(address(1), address(2), address(0));
+        manager.updateConfig(address(1), address(0));
     }
 
     function testPauseAndUnpauseEmitsEventsAndChangesState() public {


### PR DESCRIPTION
This pull request simplifies the configuration management of the `WithdrawalManager` contract by removing the `coreContract` address from its `updateConfig` method and related logic. The change impacts both the contract implementation and its associated tests, ensuring that only the relevant contract addresses are managed and validated.