### PR TITLE
fix: prevent fee collection when AUM is non-positive and add corresponding tests

### DIFF
--- a/src/MaxBTCCore.sol
+++ b/src/MaxBTCCore.sol
@@ -1,12 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.28;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {
+    Initializable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {
+    UUPSUpgradeable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {
+    Ownable2StepUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {
+    SafeERC20
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {
+    IERC20Metadata
+} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {MaxBTCERC20} from "./MaxBTCERC20.sol";
 import {WithdrawalToken} from "./WithdrawalToken.sol";
 import {WaitosaurHolder} from "./WaitosaurHolder.sol";
@@ -121,6 +131,7 @@ contract MaxBTCCore is Initializable, UUPSUpgradeable, Ownable2StepUpgradeable {
     error FeeTooHigh();
     error SlippageLimitExceeded(uint256 requested, uint256 actual);
     error WaitosaurLocked();
+    error AumMustBePositive();
 
     /// @dev keccak256(abi.encode(uint256(keccak256("maxbtc.core.config")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant CONFIG_STORAGE_SLOT =
@@ -501,6 +512,13 @@ contract MaxBTCCore is Initializable, UUPSUpgradeable, Ownable2StepUpgradeable {
         if (_msgSender() != config.feeCollector) {
             revert InvalidFeeCollectorAddress();
         }
+
+        (int256 aumRaw, ) = IExchangeRateProvider(config.exchangeRateProvider)
+            .getAum();
+        if (aumRaw <= 0) {
+            revert AumMustBePositive();
+        }
+
         MaxBTCERC20(config.maxBtcToken).mint(_msgSender(), amount);
         emit FeeMinted(_msgSender(), amount);
     }

--- a/test/MaxBTCCore.test.sol
+++ b/test/MaxBTCCore.test.sol
@@ -161,6 +161,7 @@ contract MaxBTCCoreTest is Test {
         waitosaurHolder.updateConfig(WITHDRAWAL_MANAGER);
 
         allowlist.allow(_arr(USER));
+        provider.publishAum(int256(1), depositToken.decimals());
     }
 
     function testDepositMintsWithFeeAndAllowlist() external {
@@ -209,6 +210,7 @@ contract MaxBTCCoreTest is Test {
 
     function testMintFeeRevertsWhenAumNonPositive() external {
         uint256 amount = 1e7;
+        provider.publishAum(int256(-1), depositToken.decimals());
         // do not publish AUM (default 0) -> should revert
         vm.prank(FEE_COLLECTOR);
         vm.expectRevert(MaxBTCCore.AumMustBePositive.selector);

--- a/test/MaxBTCCore.test.sol
+++ b/test/MaxBTCCore.test.sol
@@ -10,7 +10,9 @@ import {WaitosaurHolder} from "../src/WaitosaurHolder.sol";
 import {Allowlist} from "../src/Allowlist.sol";
 import {Receiver} from "../src/Receiver.sol";
 import {Batch} from "../src/types/CoreTypes.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract MockERC20 is ERC20 {
     uint8 private immutable _DECIMALS;
@@ -199,9 +201,18 @@ contract MaxBTCCoreTest is Test {
 
     function testMintFeeByCollector() external {
         uint256 amount = 3e7;
+        provider.publishAum(int256(1), depositToken.decimals());
         vm.prank(FEE_COLLECTOR);
         core.mintFee(amount);
         assertEq(maxbtc.balanceOf(FEE_COLLECTOR), amount, "fee minted");
+    }
+
+    function testMintFeeRevertsWhenAumNonPositive() external {
+        uint256 amount = 1e7;
+        // do not publish AUM (default 0) -> should revert
+        vm.prank(FEE_COLLECTOR);
+        vm.expectRevert(MaxBTCCore.AumMustBePositive.selector);
+        core.mintFee(amount);
     }
 
     function testDepositRejectsNotAllowlisted() external {

--- a/test/MaxBTCCoreIntegration.test.sol
+++ b/test/MaxBTCCoreIntegration.test.sol
@@ -3,8 +3,12 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    SafeERC20
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {MaxBTCCore} from "../src/MaxBTCCore.sol";
 import {MaxBTCERC20} from "../src/MaxBTCERC20.sol";
@@ -177,12 +181,7 @@ contract MaxBTCCoreIntegrationTest is Test {
         waitosaurHolder.updateConfig(address(manager));
 
         // Now initialize dependent contracts with the finalized core address.
-        maxbtc.initialize(
-            address(this),
-            address(this),
-            "maxBTC",
-            "maxBTC"
-        );
+        maxbtc.initialize(address(this), address(this), "maxBTC", "maxBTC");
         maxbtc.initializeV2(address(core));
         withdrawalToken.initialize(
             address(this),
@@ -379,6 +378,7 @@ contract MaxBTCCoreIntegrationTest is Test {
         vm.warp(block.timestamp + 2);
         provider.publish(11e17, block.timestamp); // 1.1x ER
 
+        provider.publishAum(int256(wbtc.totalSupply()), wbtc.decimals());
         // Collect fee (mints to feeCollector address through core.mintFee)
         vm.prank(OWNER);
         feeCollector.collectFee();


### PR DESCRIPTION
This pull request introduces a new safety check to the `MaxBTCCore` contract to ensure that the Assets Under Management (AUM) value is positive before allowing fee minting. It also adds corresponding tests to verify this behavior, and makes some minor formatting improvements to import statements for better readability