### PR TITLE
Missing oracle staleness validation before using price data

### DIFF
--- a/src/FeeCollector.sol
+++ b/src/FeeCollector.sol
@@ -39,6 +39,7 @@ contract FeeCollector is
     uint256 private constant ONE = 1e18;
     uint256 private constant MIN_COLLECTION_PERIOD_SECONDS = 60 * 60; // one hour
     uint256 private constant MAX_COLLECTION_PERIOD_SECONDS = 60 * 60 * 24 * 30; // one month
+    uint256 private constant MAX_STALENESS_THRESHOLD_SECONDS = 60 * 60 * 24 * 7; // one week
 
     struct Config {
         address coreContract;
@@ -71,6 +72,7 @@ contract FeeCollector is
     error InvalidZeroAmount();
     error InvalidErReceiverAddress();
     error InvalidCollectionPeriodSeconds();
+    error InvalidStalenessThreshold();
     error StaleExchangeRate(
         uint256 dataTimestamp,
         uint256 currentTimestamp,
@@ -145,6 +147,12 @@ contract FeeCollector is
         config.feeApyReductionPercentage = feeApyReductionPercentage_;
         config.collectionPeriodSeconds = collectionPeriodSeconds_;
         config.feeToken = IERC20(feeToken_);
+        if (
+            stalenessThreshold_ == 0 ||
+            stalenessThreshold_ > MAX_STALENESS_THRESHOLD_SECONDS
+        ) {
+            revert InvalidStalenessThreshold();
+        }
         config.stalenessThreshold = stalenessThreshold_;
 
         (uint256 initialRate, uint256 initialTimestamp) = IReceiver(erReceiver_)
@@ -242,6 +250,12 @@ contract FeeCollector is
             newCollectionPeriodSeconds > MAX_COLLECTION_PERIOD_SECONDS
         ) {
             revert InvalidCollectionPeriodSeconds();
+        }
+        if (
+            newStalenessThreshold == 0 ||
+            newStalenessThreshold > MAX_STALENESS_THRESHOLD_SECONDS
+        ) {
+            revert InvalidStalenessThreshold();
         }
 
         Config storage config = _getConfig();

--- a/src/WaitosaurBase.sol
+++ b/src/WaitosaurBase.sol
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {
+    Initializable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {
+    UUPSUpgradeable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {
+    Ownable2StepUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 struct WaitosaurState {
     uint256 lockedAmount;

--- a/src/WaitosaurObserver.sol
+++ b/src/WaitosaurObserver.sol
@@ -26,6 +26,7 @@ contract WaitosaurObserver is WaitosaurBase {
     error InvalidOracleAddress();
     error InvalidAsset();
     error ConfigCantBeUpdatedWhenLocked();
+    error InvalidStalenessThreshold();
     error StaleOracleData(
         uint256 dataTimestamp,
         uint256 currentTimestamp,
@@ -37,6 +38,9 @@ contract WaitosaurObserver is WaitosaurBase {
     // ---------------------------------------------------------------------
 
     event ConfigUpdated(WaitosaurObserverConfig config);
+
+    // Maximum allowed staleness threshold default (one week)
+    uint256 private constant MAX_STALENESS_THRESHOLD = 60 * 60 * 24 * 7;
 
     // ---------------------------------------------------------------------
     // Slots
@@ -76,6 +80,12 @@ contract WaitosaurObserver is WaitosaurBase {
         WaitosaurObserverConfig storage config = _config();
         config.oracle = oracle_;
         config.asset = asset_;
+        if (
+            stalenessThreshold_ == 0 ||
+            stalenessThreshold_ > MAX_STALENESS_THRESHOLD
+        ) {
+            revert InvalidStalenessThreshold();
+        }
         config.stalenessThreshold = stalenessThreshold_;
 
         // Verify initial oracle data is not stale
@@ -111,6 +121,9 @@ contract WaitosaurObserver is WaitosaurBase {
             config.asset = newAsset;
         }
         if (newStalenessThreshold != 0) {
+            if (newStalenessThreshold > MAX_STALENESS_THRESHOLD) {
+                revert InvalidStalenessThreshold();
+            }
             config.stalenessThreshold = newStalenessThreshold;
         }
 

--- a/test/FeeCollector.test.sol
+++ b/test/FeeCollector.test.sol
@@ -2,9 +2,13 @@
 pragma solidity ^0.8.28;
 
 import {Test, console2} from "forge-std/Test.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {FeeCollector, IReceiver, ICoreContract} from "../src/FeeCollector.sol"; // adjust the path if needed
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {
+    OwnableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract MockERC20 is ERC20 {
@@ -89,7 +93,8 @@ contract FeeCollectorTest is Test {
         address erReceiver_,
         uint256 feeApyReductionPercentage_,
         uint64 collectionPeriodSeconds_,
-        address feeToken_
+        address feeToken_,
+        uint256 stalenessThreshold_
     ) internal returns (FeeCollector) {
         FeeCollector impl = new FeeCollector();
         bytes memory data = abi.encodeWithSelector(
@@ -99,7 +104,8 @@ contract FeeCollectorTest is Test {
             erReceiver_,
             feeApyReductionPercentage_,
             collectionPeriodSeconds_,
-            feeToken_
+            feeToken_,
+            stalenessThreshold_
         );
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), data);
         return FeeCollector(address(proxy));
@@ -116,7 +122,8 @@ contract FeeCollectorTest is Test {
             address(core),
             0.1e18, // 10% APY reduction as fee
             3600, // 1 hour collection period
-            address(maxbtc)
+            address(maxbtc),
+            3600 // 1 hour staleness threshold
         );
 
         core.setFeeToken(maxbtc, address(feeCollector));
@@ -153,7 +160,8 @@ contract FeeCollectorTest is Test {
             address(core),
             0.1e18,
             3600,
-            address(maxbtc)
+            address(maxbtc),
+            3600
         );
         vm.expectRevert(FeeCollector.InvalidCoreContractAddress.selector);
         new ERC1967Proxy(address(impl), data);
@@ -168,7 +176,8 @@ contract FeeCollectorTest is Test {
             address(0), // invalid exchanage rate receiver
             0.1e18,
             3600,
-            address(maxbtc)
+            address(maxbtc),
+            3600
         );
         vm.expectRevert(FeeCollector.InvalidErReceiverAddress.selector);
         new ERC1967Proxy(address(impl), data);
@@ -183,7 +192,8 @@ contract FeeCollectorTest is Test {
             address(core),
             0.1e18,
             3600,
-            address(0) // invalid token
+            address(0), // invalid token
+            3600
         );
         vm.expectRevert(FeeCollector.InvalidFeeTokenAddress.selector);
         new ERC1967Proxy(address(impl), data);
@@ -198,7 +208,8 @@ contract FeeCollectorTest is Test {
             address(core),
             0, // invalid
             3600,
-            address(maxbtc)
+            address(maxbtc),
+            3600
         );
         vm.expectRevert(FeeCollector.InvalidFeeReductionPercentage.selector);
         new ERC1967Proxy(address(impl), data);
@@ -213,7 +224,8 @@ contract FeeCollectorTest is Test {
             address(core),
             ONE, // >= 1.0 invalid
             3600,
-            address(maxbtc)
+            address(maxbtc),
+            3600
         );
         vm.expectRevert(FeeCollector.InvalidFeeReductionPercentage.selector);
         new ERC1967Proxy(address(impl), data);
@@ -230,7 +242,8 @@ contract FeeCollectorTest is Test {
             address(core),
             0.1e18,
             60 * 60 - 1,
-            address(maxbtc)
+            address(maxbtc),
+            3600
         );
         vm.expectRevert(FeeCollector.InvalidCollectionPeriodSeconds.selector);
         new ERC1967Proxy(address(impl), data);
@@ -247,7 +260,8 @@ contract FeeCollectorTest is Test {
             address(core),
             0.1e18,
             60 * 60 * 24 * 30 + 1,
-            address(maxbtc)
+            address(maxbtc),
+            3600
         );
         vm.expectRevert(FeeCollector.InvalidCollectionPeriodSeconds.selector);
         new ERC1967Proxy(address(impl), data);
@@ -301,6 +315,83 @@ contract FeeCollectorTest is Test {
             )
         );
         feeCollector.collectFee();
+    }
+
+    function testInitializeRevertsOnStaleExchangeRate() public {
+        // Set up a mock with stale data
+        MockCore staleCore = new MockCore();
+        staleCore.setRate(1e18);
+
+        // Warp time forward to make the exchange rate stale
+        vm.warp(block.timestamp + 7200); // 2 hours later
+
+        FeeCollector impl = new FeeCollector();
+        bytes memory data = abi.encodeWithSelector(
+            FeeCollector.initialize.selector,
+            owner,
+            address(staleCore),
+            address(staleCore),
+            0.1e18,
+            3600,
+            address(maxbtc),
+            3600 // 1 hour staleness threshold
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FeeCollector.StaleExchangeRate.selector,
+                staleCore.publishedAt(),
+                block.timestamp,
+                3600
+            )
+        );
+        new ERC1967Proxy(address(impl), data);
+    }
+
+    function testCollectFeeRevertsOnStaleExchangeRate() public {
+        maxbtc.mint(address(0xCAFE), 1_000_000 * 10 ** 8);
+
+        // Set initial rate
+        uint256 oldRate = core.exchangeRate();
+        uint256 newRate = oldRate + 0.2e18;
+        core.setRate(newRate);
+
+        uint256 rateTimestamp = core.publishedAt();
+
+        // Move forward past both collection period and staleness threshold
+        vm.warp(block.timestamp + 7700); // Make data stale (> 3600 seconds from rateTimestamp)
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                FeeCollector.StaleExchangeRate.selector,
+                rateTimestamp,
+                block.timestamp,
+                3600
+            )
+        );
+        feeCollector.collectFee();
+    }
+
+    function testCollectFeeSucceedsWithFreshExchangeRate() public {
+        maxbtc.mint(address(0xCAFE), 1_000_000 * 10 ** 8);
+
+        // Move forward past collection period
+        vm.warp(block.timestamp + 4000);
+
+        // Update rate properly (this updates both rate and timestamp)
+        uint256 oldRate = core.exchangeRate();
+        uint256 newRate = oldRate + 0.2e18;
+        core.setRate(newRate);
+
+        // This should succeed because the data is fresh
+        feeCollector.collectFee();
+
+        FeeCollector.State memory st = feeCollector.getState();
+        assertEq(
+            st.lastExchangeRate,
+            newRate,
+            "exchange rate should be updated"
+        );
     }
 
     function testCollectFeeNoMintWhenTotalSupplyZero() public {
@@ -543,22 +634,40 @@ contract FeeCollectorTest is Test {
 
     function testUpdateConfigRevertsOnZeroCoreContract() public {
         vm.expectRevert(FeeCollector.InvalidCoreContractAddress.selector);
-        feeCollector.updateConfig(address(0), address(core), 0.2e18, 7200);
+        feeCollector.updateConfig(
+            address(0),
+            address(core),
+            0.2e18,
+            7200,
+            3600
+        );
     }
 
     function testUpdateConfigRevertsOnZeroErReceiverContract() public {
         vm.expectRevert(FeeCollector.InvalidErReceiverAddress.selector);
-        feeCollector.updateConfig(address(core), address(0), 0.2e18, 7200);
+        feeCollector.updateConfig(
+            address(core),
+            address(0),
+            0.2e18,
+            7200,
+            3600
+        );
     }
 
     function testUpdateConfigRevertsOnInvalidFeeReductionZero() public {
         vm.expectRevert(FeeCollector.InvalidFeeReductionPercentage.selector);
-        feeCollector.updateConfig(address(core), address(core), 0, 7200);
+        feeCollector.updateConfig(address(core), address(core), 0, 7200, 3600);
     }
 
     function testUpdateConfigRevertsOnInvalidFeeReductionTooHigh() public {
         vm.expectRevert(FeeCollector.InvalidFeeReductionPercentage.selector);
-        feeCollector.updateConfig(address(core), address(core), ONE, 7200);
+        feeCollector.updateConfig(
+            address(core),
+            address(core),
+            ONE,
+            7200,
+            3600
+        );
     }
 
     function testUpdateConfigRevertsOnInvalidCollectionPeriodSecondsTooLow()
@@ -569,7 +678,8 @@ contract FeeCollectorTest is Test {
             address(core),
             address(core),
             0.1e18,
-            60 * 60 - 1
+            60 * 60 - 1,
+            7200
         );
     }
 
@@ -581,7 +691,8 @@ contract FeeCollectorTest is Test {
             address(core),
             address(core),
             0.1e18,
-            60 * 60 * 24 * 30 + 1
+            60 * 60 * 24 * 30 + 1,
+            7200
         );
     }
 
@@ -595,14 +706,16 @@ contract FeeCollectorTest is Test {
             address(newCore),
             address(core),
             0.2e18,
-            10_000
+            10_000,
+            7200
         );
 
         feeCollector.updateConfig(
             address(newCore),
             address(core),
             0.2e18,
-            10_000
+            10_000,
+            7200
         );
 
         FeeCollector.Config memory cfg = feeCollector.getConfig();
@@ -639,7 +752,13 @@ contract FeeCollectorTest is Test {
                 other
             )
         );
-        feeCollector.updateConfig(address(core), address(core), 0.2e18, 7200);
+        feeCollector.updateConfig(
+            address(core),
+            address(core),
+            0.2e18,
+            7200,
+            3600
+        );
     }
 
     // --------------------------------------
@@ -656,7 +775,8 @@ contract FeeCollectorTest is Test {
             address(core),
             0.1e18,
             3600,
-            address(maxbtc)
+            address(maxbtc),
+            3600
         );
     }
 
@@ -670,7 +790,8 @@ contract FeeCollectorTest is Test {
             address(core),
             0.1e18,
             3600,
-            address(maxbtc)
+            address(maxbtc),
+            3600
         );
 
         ERC1967Proxy proxy = new ERC1967Proxy(address(impl), data);

--- a/test/MaxBTCCoreIntegration.test.sol
+++ b/test/MaxBTCCoreIntegration.test.sol
@@ -205,7 +205,8 @@ contract MaxBTCCoreIntegrationTest is Test {
             address(provider),
             FEE_REDUCTION,
             3600,
-            address(maxbtc)
+            address(maxbtc),
+            3600
         );
 
         // address(this) plays role of ics20 for maxBTC ERC20 contract, hence

--- a/test/MaxBTCCoreIntegration.test.sol
+++ b/test/MaxBTCCoreIntegration.test.sol
@@ -45,15 +45,21 @@ contract MockERC20 is ERC20 {
 
 contract MockAumOracle is IAumOracle {
     uint256 public balance;
+    uint256 public timestamp;
+
+    constructor() {
+        timestamp = block.timestamp;
+    }
 
     function setBalance(uint256 newBalance) external {
         balance = newBalance;
+        timestamp = block.timestamp;
     }
 
     function getSpotBalance(
         string calldata /* asset */
-    ) external view returns (uint256) {
-        return balance;
+    ) external view returns (uint256, uint256) {
+        return (balance, timestamp);
     }
 }
 
@@ -141,7 +147,14 @@ contract MaxBTCCoreIntegrationTest is Test {
             address(waitosaurObserverImpl),
             abi.encodeCall(
                 WaitosaurObserver.initialize,
-                (address(this), address(this), OPERATOR, address(oracle), "BTC")
+                (
+                    address(this),
+                    address(this),
+                    OPERATOR,
+                    address(oracle),
+                    "BTC",
+                    3600
+                )
             )
         );
         waitosaurObserver = WaitosaurObserver(address(waitosaurObserverProxy));
@@ -176,7 +189,7 @@ contract MaxBTCCoreIntegrationTest is Test {
         withdrawalToken = WithdrawalToken(address(withdrawalProxy));
         manager = WithdrawalManager(address(managerProxy));
         waitosaurObserver.updateRoles(address(core), OPERATOR);
-        waitosaurObserver.updateConfig(address(oracle), "");
+        waitosaurObserver.updateConfig(address(oracle), "", 0);
         waitosaurHolder.updateRoles(OPERATOR, address(core));
         waitosaurHolder.updateConfig(address(manager));
 

--- a/test/WaitosaurObserver.test.sol
+++ b/test/WaitosaurObserver.test.sol
@@ -150,6 +150,28 @@ contract WaitosaurObserverTest is Test {
         fresh.initialize(owner, locker, unlocker, address(oracle), "", 3600);
     }
 
+    function testInitializeZeroStalenessReverts() public {
+        WaitosaurObserver fresh = _deployUninitializedProxy();
+        vm.prank(owner);
+        vm.expectRevert(WaitosaurObserver.InvalidStalenessThreshold.selector);
+        fresh.initialize(owner, locker, unlocker, address(oracle), asset, 0);
+    }
+
+    function testInitializeTooLargeStalenessReverts() public {
+        WaitosaurObserver fresh = _deployUninitializedProxy();
+        vm.prank(owner);
+        vm.expectRevert(WaitosaurObserver.InvalidStalenessThreshold.selector);
+        // use a very large value to exceed any reasonable MAX_STALENESS_THRESHOLD
+        fresh.initialize(
+            owner,
+            locker,
+            unlocker,
+            address(oracle),
+            asset,
+            type(uint256).max
+        );
+    }
+
     function testInitializeTwiceReverts() public {
         WaitosaurObserver fresh = _deployUninitializedProxy();
         vm.prank(owner);
@@ -398,6 +420,13 @@ contract WaitosaurObserverTest is Test {
             WaitosaurObserver.ConfigCantBeUpdatedWhenLocked.selector
         );
         observer.updateConfig(address(0x12), "ETH", 0);
+    }
+
+    function testUpdateConfigInvalidStalenessReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(WaitosaurObserver.InvalidStalenessThreshold.selector);
+        // supply an absurdly large threshold to trigger the "too large" branch
+        observer.updateConfig(address(0), "", type(uint256).max);
     }
 
     // -------------------------------------------------------------


### PR DESCRIPTION
### Description
The protocol lacks oracle staleness checks in critical price-dependent operations:
1. In src/WaitosaurObserver.sol:112-118, the contract uses oracle prices
without validating their freshness, allowing potentially outdated prices to be used in
calculations.
2. In src/FeeCollector.sol:140-150, the FeeCollector contract does not check
oracle staleness when calculating fees, while MaxBTCCore does implement staleness
checks for deposits and withdrawals.
3. In src/MaxBTCCore.sol:521-523, oracle values are never validated for
staleness or checked against min/max price bounds, relying solely on off-chain
protections without on-chain fallback mechanisms.
This inconsistency creates a vulnerability where stale prices could be exploited in fee
calculations.
An attacker could exploit stale oracle prices during market volatility to execute trades at
favorable prices when the real market has moved significantly, manipulate pool AUM
calculations for profit, or cause incorrect minimum output calculations in liquidity operations.

### Recommendation
We recommend adding oracle staleness checks before consuming price data.
Specifically, validate the oracle’s timestamp to ensure the reported price is sufficiently recent
(for example, within the last five minutes) by comparing it against the current time.