### PR TITLE
AUM Oracle state validation for Waitosaur

### DIFF
--- a/src/WaitosaurBase.sol
+++ b/src/WaitosaurBase.sol
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {
+    Initializable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {
+    UUPSUpgradeable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {
+    Ownable2StepUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 struct WaitosaurState {
     uint256 lockedAmount;
@@ -16,7 +22,11 @@ struct WaitosaurAccess {
     address unlocker;
 }
 
-abstract contract WaitosaurBase is Initializable, UUPSUpgradeable, Ownable2StepUpgradeable {
+abstract contract WaitosaurBase is
+    Initializable,
+    UUPSUpgradeable,
+    Ownable2StepUpgradeable
+{
     // ---------------------------------------------------------------------
     // Errors
     // ---------------------------------------------------------------------
@@ -42,9 +52,11 @@ abstract contract WaitosaurBase is Initializable, UUPSUpgradeable, Ownable2StepU
     // ---------------------------------------------------------------------
 
     /// @dev keccak256(abi.encode(uint256(keccak256("maxbtc.waitosaur.base.state")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 internal constant STATE_STORAGE_SLOT = 0xb625a17d914f4b51b828255a041dd3685dd0ee72e56b573af3d2e7026d744a00;
+    bytes32 internal constant STATE_STORAGE_SLOT =
+        0xb625a17d914f4b51b828255a041dd3685dd0ee72e56b573af3d2e7026d744a00;
     /// @dev keccak256(abi.encode(uint256(keccak256("maxbtc.waitosaur.base.roles")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 internal constant ROLES_STORAGE_SLOT = 0x0a2710fa198f5ddf1285643038b49c62a676636b17744ae31f3856897d341700;
+    bytes32 internal constant ROLES_STORAGE_SLOT =
+        0x0a2710fa198f5ddf1285643038b49c62a676636b17744ae31f3856897d341700;
 
     function _getState() internal pure returns (WaitosaurState storage s) {
         assembly {
@@ -68,7 +80,11 @@ abstract contract WaitosaurBase is Initializable, UUPSUpgradeable, Ownable2StepU
         return r;
     }
 
-    function __WaitosaurBase_init(address owner_, address locker_, address unlocker_) internal onlyInitializing {
+    function __WaitosaurBase_init(
+        address owner_,
+        address locker_,
+        address unlocker_
+    ) internal onlyInitializing {
         __Ownable_init(owner_);
         __Ownable2Step_init();
         __UUPSUpgradeable_init();
@@ -79,7 +95,10 @@ abstract contract WaitosaurBase is Initializable, UUPSUpgradeable, Ownable2StepU
 
     function _setRoles(address locker, address unlocker) internal {
         WaitosaurAccess storage r = _getRoles();
-        require(locker != address(0) && unlocker != address(0), InvalidRolesAddresses());
+        require(
+            locker != address(0) && unlocker != address(0),
+            InvalidRolesAddresses()
+        );
 
         r.locker = locker;
         r.unlocker = unlocker;
@@ -87,11 +106,17 @@ abstract contract WaitosaurBase is Initializable, UUPSUpgradeable, Ownable2StepU
         emit RolesUpdated(r);
     }
 
-    function updateRoles(address newLocker, address newUnlocker) public onlyOwner {
+    function updateRoles(
+        address newLocker,
+        address newUnlocker
+    ) public onlyOwner {
         _setRoles(newLocker, newUnlocker);
     }
 
-    function _lockBase(uint256 amount, uint256 initialOracleBalance) internal returns (WaitosaurState storage state) {
+    function _lockBase(
+        uint256 amount,
+        uint256 initialOracleBalance
+    ) internal returns (WaitosaurState storage state) {
         if (amount == 0) revert AmountZero();
         state = _getState();
         if (state.lockedAmount != 0) revert AlreadyLocked();
@@ -112,8 +137,13 @@ abstract contract WaitosaurBase is Initializable, UUPSUpgradeable, Ownable2StepU
     }
 
     /// @notice Override this to provide initial oracle balance before locking
-    function _getInitialOracleBalance() internal view virtual returns (uint256) {
-        return 0;
+    function _getInitialOracleBalance()
+        internal
+        view
+        virtual
+        returns (uint256)
+    {
+        revert("_getInitialOracleBalance is not implemented");
     }
 
     /// @dev Only unlocker or owner is allowed.
@@ -129,7 +159,7 @@ abstract contract WaitosaurBase is Initializable, UUPSUpgradeable, Ownable2StepU
         emit Unlocked();
     }
 
-    function _unlock() internal virtual { }
+    function _unlock() internal virtual {}
 
     function lastLocked() public view returns (uint256) {
         return _getState().lastLocked;

--- a/src/WaitosaurBase.sol
+++ b/src/WaitosaurBase.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { Ownable2StepUpgradeable } from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 struct WaitosaurState {
     uint256 lockedAmount;
     uint256 lastLocked;
+    uint256 initialOracleBalance;
 }
 
 struct WaitosaurAccess {
@@ -15,11 +16,7 @@ struct WaitosaurAccess {
     address unlocker;
 }
 
-abstract contract WaitosaurBase is
-    Initializable,
-    UUPSUpgradeable,
-    Ownable2StepUpgradeable
-{
+abstract contract WaitosaurBase is Initializable, UUPSUpgradeable, Ownable2StepUpgradeable {
     // ---------------------------------------------------------------------
     // Errors
     // ---------------------------------------------------------------------
@@ -30,6 +27,7 @@ abstract contract WaitosaurBase is
     error InvalidRolesAddresses();
     error InsufficientAssetAmount();
     error Unauthorized();
+    error OracleBalanceIncorrect();
 
     // ---------------------------------------------------------------------
     // Events
@@ -44,11 +42,9 @@ abstract contract WaitosaurBase is
     // ---------------------------------------------------------------------
 
     /// @dev keccak256(abi.encode(uint256(keccak256("maxbtc.waitosaur.base.state")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 internal constant STATE_STORAGE_SLOT =
-        0xb625a17d914f4b51b828255a041dd3685dd0ee72e56b573af3d2e7026d744a00;
+    bytes32 internal constant STATE_STORAGE_SLOT = 0xb625a17d914f4b51b828255a041dd3685dd0ee72e56b573af3d2e7026d744a00;
     /// @dev keccak256(abi.encode(uint256(keccak256("maxbtc.waitosaur.base.roles")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 internal constant ROLES_STORAGE_SLOT =
-        0x0a2710fa198f5ddf1285643038b49c62a676636b17744ae31f3856897d341700;
+    bytes32 internal constant ROLES_STORAGE_SLOT = 0x0a2710fa198f5ddf1285643038b49c62a676636b17744ae31f3856897d341700;
 
     function _getState() internal pure returns (WaitosaurState storage s) {
         assembly {
@@ -72,11 +68,7 @@ abstract contract WaitosaurBase is
         return r;
     }
 
-    function __WaitosaurBase_init(
-        address owner_,
-        address locker_,
-        address unlocker_
-    ) internal onlyInitializing {
+    function __WaitosaurBase_init(address owner_, address locker_, address unlocker_) internal onlyInitializing {
         __Ownable_init(owner_);
         __Ownable2Step_init();
         __UUPSUpgradeable_init();
@@ -87,10 +79,7 @@ abstract contract WaitosaurBase is
 
     function _setRoles(address locker, address unlocker) internal {
         WaitosaurAccess storage r = _getRoles();
-        require(
-            locker != address(0) && unlocker != address(0),
-            InvalidRolesAddresses()
-        );
+        require(locker != address(0) && unlocker != address(0), InvalidRolesAddresses());
 
         r.locker = locker;
         r.unlocker = unlocker;
@@ -98,38 +87,41 @@ abstract contract WaitosaurBase is
         emit RolesUpdated(r);
     }
 
-    function updateRoles(
-        address newLocker,
-        address newUnlocker
-    ) public onlyOwner {
+    function updateRoles(address newLocker, address newUnlocker) public onlyOwner {
         _setRoles(newLocker, newUnlocker);
     }
 
-    function _lockBase(
-        uint256 amount
-    ) internal returns (WaitosaurState storage state) {
+    function _lockBase(uint256 amount, uint256 initialOracleBalance) internal returns (WaitosaurState storage state) {
         if (amount == 0) revert AmountZero();
         state = _getState();
         if (state.lockedAmount != 0) revert AlreadyLocked();
         state.lockedAmount = amount;
         state.lastLocked = block.timestamp;
+        state.initialOracleBalance = initialOracleBalance;
 
         emit Locked(amount);
     }
 
-    function lock(uint256 amount) public {
+    function lock(uint256 amount) public virtual {
         WaitosaurAccess storage roles = _getRoles();
         if (_msgSender() != roles.locker && _msgSender() != owner()) {
             revert Unauthorized();
         }
-        _lockBase(amount);
+        uint256 initialBalance = _getInitialOracleBalance();
+        _lockBase(amount, initialBalance);
+    }
+
+    /// @notice Override this to provide initial oracle balance before locking
+    function _getInitialOracleBalance() internal view virtual returns (uint256) {
+        return 0;
     }
 
     /// @dev Only unlocker or owner is allowed.
     function unlock() external {
         WaitosaurAccess storage roles = _getRoles();
-        if (_msgSender() != roles.unlocker && _msgSender() != owner())
+        if (_msgSender() != roles.unlocker && _msgSender() != owner()) {
             revert Unauthorized();
+        }
         WaitosaurState storage state = _getState();
         _ensureLocked(state);
         _unlock();
@@ -137,7 +129,7 @@ abstract contract WaitosaurBase is
         emit Unlocked();
     }
 
-    function _unlock() internal virtual {}
+    function _unlock() internal virtual { }
 
     function lastLocked() public view returns (uint256) {
         return _getState().lastLocked;
@@ -158,5 +150,6 @@ abstract contract WaitosaurBase is
     function _clearLock(WaitosaurState storage state) internal {
         state.lockedAmount = 0;
         state.lastLocked = 0;
+        state.initialOracleBalance = 0;
     }
 }

--- a/src/WaitosaurHolder.sol
+++ b/src/WaitosaurHolder.sol
@@ -95,7 +95,7 @@ contract WaitosaurHolder is WaitosaurBase {
     function _getInitialOracleBalance()
         internal
         view
-        override
+        override(WaitosaurBase)
         returns (uint256)
     {
         WaitosaurHolderConfig storage config = _getWaitosaurConfig();

--- a/src/WaitosaurHolder.sol
+++ b/src/WaitosaurHolder.sol
@@ -92,12 +92,25 @@ contract WaitosaurHolder is WaitosaurBase {
     // Overrides
     // ---------------------------------------------------------------------
 
+    function _getInitialOracleBalance()
+        internal
+        view
+        override
+        returns (uint256)
+    {
+        WaitosaurHolderConfig storage config = _getWaitosaurConfig();
+        IERC20 tokenERC20 = IERC20(config.token);
+        return tokenERC20.balanceOf(address(this));
+    }
+
     function _unlock() internal override(WaitosaurBase) {
         WaitosaurHolderConfig storage config = _getWaitosaurConfig();
         WaitosaurState storage state = _getState();
         IERC20 tokenERC20 = IERC20(config.token);
 
         uint256 balance = tokenERC20.balanceOf(address(this));
+        // For Holder, we just need to ensure we have enough balance
+        // The tokens are already in the contract, so we don't require balance increase
         if (balance < state.lockedAmount) revert InsufficientAssetAmount();
         SafeERC20.safeTransfer(tokenERC20, config.receiver, state.lockedAmount);
     }

--- a/src/WaitosaurObserver.sol
+++ b/src/WaitosaurObserver.sol
@@ -111,7 +111,7 @@ contract WaitosaurObserver is WaitosaurBase {
     function _getInitialOracleBalance()
         internal
         view
-        override
+        override(WaitosaurBase)
         returns (uint256)
     {
         WaitosaurObserverConfig storage config = _config();

--- a/src/WaitosaurObserver.sol
+++ b/src/WaitosaurObserver.sol
@@ -108,6 +108,16 @@ contract WaitosaurObserver is WaitosaurBase {
     // Overrides
     // ---------------------------------------------------------------------
 
+    function _getInitialOracleBalance()
+        internal
+        view
+        override
+        returns (uint256)
+    {
+        WaitosaurObserverConfig storage config = _config();
+        return IAumOracle(config.oracle).getSpotBalance(config.asset);
+    }
+
     function _unlock() internal view override(WaitosaurBase) {
         WaitosaurObserverConfig storage config = _config();
         WaitosaurState storage state = _getState();
@@ -115,7 +125,12 @@ contract WaitosaurObserver is WaitosaurBase {
             config.asset
         );
 
-        if (spotBalance < state.lockedAmount) {
+        // Verify that balance increased by at least the locked amount
+        // Use subtraction to avoid overflow
+        if (spotBalance < state.initialOracleBalance) {
+            revert OracleBalanceIncorrect();
+        }
+        if (spotBalance - state.initialOracleBalance < state.lockedAmount) {
             revert InsufficientAssetAmount();
         }
     }

--- a/test/MaxBTCCoreIntegration.test.sol
+++ b/test/MaxBTCCoreIntegration.test.sol
@@ -106,7 +106,8 @@ contract MaxBTCCoreIntegrationTest is Test {
         allowlist = Allowlist(address(allowlistProxy));
         allowlist.allow(_arr(USER));
         oracle = new MockAumOracle();
-        oracle.setBalance(type(uint256).max);
+        // Set initial oracle balance to a realistic high value (1M BTC in satoshis)
+        oracle.setBalance(1_000_000e8);
         // Seed ER for fee collector baseline
         provider.publish(1e18, block.timestamp);
 
@@ -289,6 +290,8 @@ contract MaxBTCCoreIntegrationTest is Test {
         assertEq(wbtc.balanceOf(DEPOSIT_FORWARDER), depositAmount, "flushed");
 
         // Unlock observer and complete cycle back to Idle
+        // Simulate oracle balance increase by the locked amount
+        oracle.setBalance(oracle.balance() + waitosaurObserver.lockedAmount());
         vm.prank(OPERATOR);
         waitosaurObserver.unlock();
         assertEq(waitosaurObserver.lockedAmount(), 0, "observer unlocked");
@@ -525,6 +528,8 @@ contract MaxBTCCoreIntegrationTest is Test {
         vm.expectRevert(MaxBTCCore.WaitosaurLocked.selector);
         core.tick();
         // Unlock and finish cycle, batch id should advance to 2 after full cycle
+        // Simulate oracle balance increase by the locked amount
+        oracle.setBalance(oracle.balance() + waitosaurObserver.lockedAmount());
         vm.prank(OPERATOR);
         waitosaurObserver.unlock();
         vm.prank(OPERATOR);
@@ -623,6 +628,8 @@ contract MaxBTCCoreIntegrationTest is Test {
         uint256 forwarderBefore = wbtc.balanceOf(DEPOSIT_FORWARDER);
         uint256 extraDeposit = 5e6;
         wbtc.mint(address(core), extraDeposit);
+        // Simulate oracle balance increase by the locked amount
+        oracle.setBalance(oracle.balance() + waitosaurObserver.lockedAmount());
         vm.prank(OPERATOR);
         waitosaurObserver.unlock(); // unlock observer for continued deposit flow
         vm.prank(OPERATOR);
@@ -680,6 +687,8 @@ contract MaxBTCCoreIntegrationTest is Test {
         core.tick();
         vm.prank(OWNER);
         core.setPaused(false);
+        // Simulate oracle balance increase by the locked amount
+        oracle.setBalance(oracle.balance() + waitosaurObserver.lockedAmount());
         vm.prank(OPERATOR);
         waitosaurObserver.unlock();
         vm.prank(OPERATOR);

--- a/test/WaitosaurBase.test.sol
+++ b/test/WaitosaurBase.test.sol
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import { Test } from "forge-std/Test.sol";
-import { WaitosaurBase, WaitosaurState, WaitosaurAccess } from "../src/WaitosaurBase.sol";
+import {Test} from "forge-std/Test.sol";
+import {
+    WaitosaurBase,
+    WaitosaurState,
+    WaitosaurAccess
+} from "../src/WaitosaurBase.sol";
 
 contract Waitosaur is WaitosaurBase {
     event UnlockCalled(uint256 amount);
 
-    function initialize(address owner_, address locker_, address unlocker_) external initializer {
+    function initialize(
+        address owner_,
+        address locker_,
+        address unlocker_
+    ) external initializer {
         __WaitosaurBase_init(owner_, locker_, unlocker_);
     }
 
@@ -16,7 +24,16 @@ contract Waitosaur is WaitosaurBase {
         emit UnlockCalled(state.lockedAmount);
     }
 
-    function _authorizeUpgrade(address) internal override onlyOwner { }
+    function _getInitialOracleBalance()
+        internal
+        view
+        override
+        returns (uint256)
+    {
+        return 0;
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
 }
 
 contract WaitosaurBaseTest is Test {
@@ -108,7 +125,9 @@ contract WaitosaurBaseTest is Test {
 
         vm.prank(owner);
         vm.expectEmit(true, true, true, true, address(waitosaur));
-        emit WaitosaurBase.RolesUpdated(WaitosaurAccess({ locker: newLocker, unlocker: newUnlocker }));
+        emit WaitosaurBase.RolesUpdated(
+            WaitosaurAccess({locker: newLocker, unlocker: newUnlocker})
+        );
         waitosaur.updateRoles(newLocker, newUnlocker);
 
         WaitosaurAccess memory roles = waitosaur.getRoles();
@@ -124,7 +143,12 @@ contract WaitosaurBaseTest is Test {
 
     function testUpdateRolesOnlyOwner() public {
         vm.prank(other);
-        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", other));
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "OwnableUnauthorizedAccount(address)",
+                other
+            )
+        );
         waitosaur.updateRoles(address(0xAA), address(0xBB));
     }
 

--- a/test/WaitosaurBase.test.sol
+++ b/test/WaitosaurBase.test.sol
@@ -1,17 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Test} from "forge-std/Test.sol";
-import {WaitosaurBase, WaitosaurState, WaitosaurAccess} from "../src/WaitosaurBase.sol";
+import { Test } from "forge-std/Test.sol";
+import { WaitosaurBase, WaitosaurState, WaitosaurAccess } from "../src/WaitosaurBase.sol";
 
 contract Waitosaur is WaitosaurBase {
     event UnlockCalled(uint256 amount);
 
-    function initialize(
-        address owner_,
-        address locker_,
-        address unlocker_
-    ) external initializer {
+    function initialize(address owner_, address locker_, address unlocker_) external initializer {
         __WaitosaurBase_init(owner_, locker_, unlocker_);
     }
 
@@ -20,7 +16,7 @@ contract Waitosaur is WaitosaurBase {
         emit UnlockCalled(state.lockedAmount);
     }
 
-    function _authorizeUpgrade(address) internal override onlyOwner {}
+    function _authorizeUpgrade(address) internal override onlyOwner { }
 }
 
 contract WaitosaurBaseTest is Test {
@@ -112,9 +108,7 @@ contract WaitosaurBaseTest is Test {
 
         vm.prank(owner);
         vm.expectEmit(true, true, true, true, address(waitosaur));
-        emit WaitosaurBase.RolesUpdated(
-            WaitosaurAccess({locker: newLocker, unlocker: newUnlocker})
-        );
+        emit WaitosaurBase.RolesUpdated(WaitosaurAccess({ locker: newLocker, unlocker: newUnlocker }));
         waitosaur.updateRoles(newLocker, newUnlocker);
 
         WaitosaurAccess memory roles = waitosaur.getRoles();
@@ -130,12 +124,7 @@ contract WaitosaurBaseTest is Test {
 
     function testUpdateRolesOnlyOwner() public {
         vm.prank(other);
-        vm.expectRevert(
-            abi.encodeWithSignature(
-                "OwnableUnauthorizedAccount(address)",
-                other
-            )
-        );
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", other));
         waitosaur.updateRoles(address(0xAA), address(0xBB));
     }
 

--- a/test/WaitosaurHolder.test.sol
+++ b/test/WaitosaurHolder.test.sol
@@ -46,8 +46,9 @@ contract MockERC20 {
         uint256 amount
     ) external returns (bool) {
         if (_balanceOf[from] < amount) revert InsufficientBalance();
-        if (allowance[from][msg.sender] < amount)
+        if (allowance[from][msg.sender] < amount) {
             revert InsufficientAllowance();
+        }
         _balanceOf[from] -= amount;
         _balanceOf[to] += amount;
         allowance[from][msg.sender] -= amount;

--- a/test/WaitosaurObserver.test.sol
+++ b/test/WaitosaurObserver.test.sol
@@ -137,7 +137,7 @@ contract WaitosaurObserverTest is Test {
     // -------------------------------------------------------------
 
     function testLockByLocker() public {
-        uint256 amount = 1_000e18;
+        uint256 amount = 1000e18;
 
         vm.prank(locker);
         observer.lock(amount);
@@ -182,7 +182,7 @@ contract WaitosaurObserverTest is Test {
     // -------------------------------------------------------------
 
     function testUnlockSuccess() public {
-        uint256 amount = 1_000e18;
+        uint256 amount = 1000e18;
 
         vm.prank(locker);
         observer.lock(amount);
@@ -197,7 +197,7 @@ contract WaitosaurObserverTest is Test {
     }
 
     function testUnlockByOwnerAllowed() public {
-        uint256 amount = 1_000e18;
+        uint256 amount = 1000e18;
 
         vm.prank(locker);
         observer.lock(amount);
@@ -211,7 +211,7 @@ contract WaitosaurObserverTest is Test {
     }
 
     function testUnlockInsufficientBalanceReverts() public {
-        uint256 amount = 1_000e18;
+        uint256 amount = 1000e18;
 
         vm.prank(locker);
         observer.lock(amount);
@@ -230,7 +230,7 @@ contract WaitosaurObserverTest is Test {
     }
 
     function testUnlockUnauthorizedReverts() public {
-        uint256 amount = 1_000e18;
+        uint256 amount = 1000e18;
 
         vm.prank(locker);
         observer.lock(amount);


### PR DESCRIPTION
### Description

In src/WaitosaurObserver.sol:109-119, the WaitosaurObserver contract lacks
validation that oracle balance is zero before locking.
While unlock checks spotBalance >= lockedAmount, it does not verify that the balance is increased by that amount. As a result, previous deposits can be double-counted. If the balance is 100 before lock(50), unlock succeeds at balance 50 instead of 150. Same logic appears in src/WaitosaurBase.sol:108-118, where _lockBase does not query or store the initial oracle balance.

### Recommendation
We recommend storing the initial oracle balance when locking and verifying that the unlock balance equals the initial balance plus the locked amount.
Alternatively, require oracle balance to be zero before allowing new locks.