### PR TITLE
fix: Add ReentrancyGuard to FeeCollector and MaxBTCCore contracts

### DIFF
--- a/src/FeeCollector.sol
+++ b/src/FeeCollector.sol
@@ -128,6 +128,7 @@ contract FeeCollector is
         __Ownable_init(owner_);
         __Ownable2Step_init();
         __UUPSUpgradeable_init();
+        __ReentrancyGuard_init();
 
         Config storage config = _getConfig();
         config.coreContract = coreContract_;

--- a/src/FeeCollector.sol
+++ b/src/FeeCollector.sol
@@ -1,11 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.28;
 
-import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import {
+    ReentrancyGuardUpgradeable
+} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {
+    Initializable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {
+    UUPSUpgradeable
+} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {
+    Ownable2StepUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {
+    SafeERC20
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 interface IReceiver {
     /// Returns current exchange rate and timestamp of publication.
@@ -20,6 +31,7 @@ interface ICoreContract {
 contract FeeCollector is
     Initializable,
     UUPSUpgradeable,
+    ReentrancyGuardUpgradeable,
     Ownable2StepUpgradeable
 {
     using SafeERC20 for IERC20;
@@ -131,7 +143,7 @@ contract FeeCollector is
         st.lastExchangeRate = initialRate;
     }
 
-    function collectFee() external {
+    function collectFee() external nonReentrant {
         Config storage config = _getConfig();
         State storage st = _getState();
 

--- a/src/MaxBTCCore.sol
+++ b/src/MaxBTCCore.sol
@@ -247,6 +247,7 @@ contract MaxBTCCore is
     ) public initializer {
         __Ownable_init(owner_);
         __Ownable2Step_init();
+        __ReentrancyGuard_init();
         if (depositToken_ == address(0)) {
             revert InvalidDepositTokenAddress();
         }


### PR DESCRIPTION
This pull request introduces reentrancy protection to both the `FeeCollector` and `MaxBTCCore` contracts by integrating OpenZeppelin's `ReentrancyGuardUpgradeable`. This helps prevent reentrancy attacks on key external functions that handle token transfers. The changes also include some import formatting for better readability