### PR TITLE
refactor: burn WT only by WM

### DIFF
--- a/src/WithdrawalToken.sol
+++ b/src/WithdrawalToken.sol
@@ -101,27 +101,19 @@ contract WithdrawalToken is
 
     function updateConfig(
         address newCoreContract,
-        string memory newName,
-        string memory newPrefix,
         address newWithdrawalManagerContract
     ) external onlyOwner {
         WithdrawalTokenConfig storage config = _getWithdrawalTokenConfig();
         if (newCoreContract == address(0)) revert InvalidCoreContractAddress();
         if (newWithdrawalManagerContract == address(0))
             revert InvalidWithdrawalManagerContractAddress();
-        if (bytes(newName).length == 0) revert InvalidName();
-        if (bytes(newPrefix).length == 0) revert InvalidPrefix();
 
         config.coreContract = newCoreContract;
-        config.name = newName;
-        config.prefix = newPrefix;
         config.withdrawalManagerContract = newWithdrawalManagerContract;
         emit ConfigSettingUpdated(
             "coreContract",
             string(abi.encodePacked(newCoreContract))
         );
-        emit ConfigSettingUpdated("name", newName);
-        emit ConfigSettingUpdated("prefix", newPrefix);
         emit ConfigSettingUpdated(
             "withdrawalManagerContract",
             string(abi.encodePacked(newWithdrawalManagerContract))

--- a/src/WithdrawalToken.sol
+++ b/src/WithdrawalToken.sol
@@ -26,7 +26,7 @@ contract WithdrawalToken is
     Ownable2StepUpgradeable,
     UUPSUpgradeable
 {
-    event ConfigSettingUpdated(string field, address newValue);
+    event ConfigSettingUpdated(string field, string newValue);
 
     struct WithdrawalTokenConfig {
         address coreContract;
@@ -83,8 +83,6 @@ contract WithdrawalToken is
         }
     }
 
-    event ConfigSettingUpdated(string field, string newValue);
-
     function name() public view returns (string memory) {
         return _getWithdrawalTokenConfig().name;
     }
@@ -118,12 +116,15 @@ contract WithdrawalToken is
         config.name = newName;
         config.prefix = newPrefix;
         config.withdrawalManagerContract = newWithdrawalManagerContract;
-        emit ConfigSettingUpdated("coreContract", newCoreContract);
+        emit ConfigSettingUpdated(
+            "coreContract",
+            string(abi.encodePacked(newCoreContract))
+        );
         emit ConfigSettingUpdated("name", newName);
         emit ConfigSettingUpdated("prefix", newPrefix);
         emit ConfigSettingUpdated(
             "withdrawalManagerContract",
-            newWithdrawalManagerContract
+            string(abi.encodePacked(newWithdrawalManagerContract))
         );
     }
 

--- a/test/MaxBTCCore.test.sol
+++ b/test/MaxBTCCore.test.sol
@@ -10,7 +10,9 @@ import {WaitosaurHolder} from "../src/WaitosaurHolder.sol";
 import {Allowlist} from "../src/Allowlist.sol";
 import {Receiver} from "../src/Receiver.sol";
 import {Batch} from "../src/types/CoreTypes.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract MockERC20 is ERC20 {
     uint8 private immutable _DECIMALS;
@@ -151,6 +153,7 @@ contract MaxBTCCoreTest is Test {
         withdrawalToken.initialize(
             address(this),
             address(core),
+            WITHDRAWAL_MANAGER,
             "ipfs://test/",
             "Redemption",
             "rMAX-"

--- a/test/MaxBTCCoreIntegration.test.sol
+++ b/test/MaxBTCCoreIntegration.test.sol
@@ -3,8 +3,12 @@ pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    SafeERC20
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {MaxBTCCore} from "../src/MaxBTCCore.sol";
 import {MaxBTCERC20} from "../src/MaxBTCERC20.sol";
@@ -177,16 +181,12 @@ contract MaxBTCCoreIntegrationTest is Test {
         waitosaurHolder.updateConfig(address(manager));
 
         // Now initialize dependent contracts with the finalized core address.
-        maxbtc.initialize(
-            address(this),
-            address(this),
-            "maxBTC",
-            "maxBTC"
-        );
+        maxbtc.initialize(address(this), address(this), "maxBTC", "maxBTC");
         maxbtc.initializeV2(address(core));
         withdrawalToken.initialize(
             address(this),
             address(core),
+            address(managerProxy),
             "ipfs://base/",
             "Redemption",
             "rMAX-"

--- a/test/WithdrawalManager.test.sol
+++ b/test/WithdrawalManager.test.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import {WithdrawalManager, ICoreContract} from "../src/WithdrawalManager.sol";
 import {WithdrawalToken} from "../src/WithdrawalToken.sol";
@@ -145,23 +147,9 @@ contract WithdrawalManagerTest is Test {
         uint256 collectedAmount = 1_000_000_000;
         core.setCollectedAmount(BATCH_ID, collectedAmount);
 
-        // Deploy WithdrawalToken via UUPS proxy
+        // Deploy WithdrawalToken via UUPS proxy (deferred init)
         WithdrawalToken tokenImpl = new WithdrawalToken();
-        bytes memory tokenInitData = abi.encodeCall(
-            WithdrawalToken.initialize,
-            (
-                owner,
-                address(core),
-                "https://api.example.com/",
-                "WithdrawalToken",
-                "WRT"
-            )
-        );
-
-        ERC1967Proxy tokenProxy = new ERC1967Proxy(
-            address(tokenImpl),
-            tokenInitData
-        );
+        ERC1967Proxy tokenProxy = new ERC1967Proxy(address(tokenImpl), "");
         token = WithdrawalToken(address(tokenProxy));
 
         // Deploy WithdrawalManager via UUPS proxy
@@ -176,6 +164,16 @@ contract WithdrawalManagerTest is Test {
             managerInitData
         );
         manager = WithdrawalManager(address(managerProxy));
+
+        // Now initialize withdrawal token with the manager address
+        token.initialize(
+            owner,
+            address(core),
+            address(managerProxy),
+            "https://api.example.com/",
+            "WithdrawalToken",
+            "WRT"
+        );
 
         // Fund WithdrawalManager with WBTC so it can redeem users
         wbtc.mint(address(manager), collectedAmount);

--- a/test/WithdrawalToken.test.sol
+++ b/test/WithdrawalToken.test.sol
@@ -95,12 +95,7 @@ contract WithdrawalTokenTest is Test {
     function testUpdateCoreAddressByOwner() public {
         address newCore = address(0xDEAD);
         vm.prank(owner);
-        token.updateConfig(
-            newCore,
-            "WithdrawalToken",
-            "WRT-",
-            withdrawalManager
-        );
+        token.updateConfig(newCore, withdrawalManager);
         // new core should be able to mint
         vm.prank(newCore);
         token.mint(user, 1, 1, "");
@@ -116,11 +111,6 @@ contract WithdrawalTokenTest is Test {
                 address(this)
             )
         );
-        token.updateConfig(
-            newCore,
-            "WithdrawalToken",
-            "WRT-",
-            withdrawalManager
-        );
+        token.updateConfig(newCore, withdrawalManager);
     }
 }


### PR DESCRIPTION
This pull request refactors the `WithdrawalToken` contract to improve configuration management and access control, and updates related tests to match the new contract interface. The main changes include consolidating several configuration parameters into a single struct stored in a dedicated storage slot, introducing a new `withdrawalManagerContract` address with stricter burn permissions, and replacing individual setters with a unified `updateConfig` function. Test files are updated to use the new initialization and configuration patterns.
