### PR TITLE
fix: add error handling for locked configuration updates in Waitosaur…

### DIFF
--- a/src/WaitosaurHolder.sol
+++ b/src/WaitosaurHolder.sol
@@ -72,8 +72,7 @@ contract WaitosaurHolder is WaitosaurBase {
     // ---------------------------------------------------------------------
 
     function updateConfig(address newReceiver) external onlyOwner {
-        WaitosaurState storage state = _getState();
-        if (state.lockedAmount > 0) revert ConfigCantBeUpdatedWhenLocked();
+        if (!unlocked()) revert ConfigCantBeUpdatedWhenLocked();
         if (newReceiver == address(0)) revert InvalidReceiverAddress();
         WaitosaurHolderConfig storage config = _getWaitosaurConfig();
         config.receiver = newReceiver;

--- a/src/WaitosaurHolder.sol
+++ b/src/WaitosaurHolder.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.28;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {
+    SafeERC20
+} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {WaitosaurBase, WaitosaurState} from "./WaitosaurBase.sol";
 
 struct WaitosaurHolderConfig {
@@ -17,6 +19,7 @@ contract WaitosaurHolder is WaitosaurBase {
 
     error InvalidTokenAddress();
     error InvalidReceiverAddress();
+    error ConfigCantBeUpdatedWhenLocked();
 
     // ---------------------------------------------------------------------
     // Events
@@ -69,6 +72,8 @@ contract WaitosaurHolder is WaitosaurBase {
     // ---------------------------------------------------------------------
 
     function updateConfig(address newReceiver) external onlyOwner {
+        WaitosaurState storage state = _getState();
+        if (state.lockedAmount > 0) revert ConfigCantBeUpdatedWhenLocked();
         if (newReceiver == address(0)) revert InvalidReceiverAddress();
         WaitosaurHolderConfig storage config = _getWaitosaurConfig();
         config.receiver = newReceiver;

--- a/src/WaitosaurObserver.sol
+++ b/src/WaitosaurObserver.sol
@@ -23,6 +23,7 @@ contract WaitosaurObserver is WaitosaurBase {
 
     error InvalidOracleAddress();
     error InvalidAsset();
+    error ConfigCantBeUpdatedWhenLocked();
 
     // ---------------------------------------------------------------------
     // Events
@@ -78,6 +79,8 @@ contract WaitosaurObserver is WaitosaurBase {
         address newOracle,
         string calldata newAsset
     ) external onlyOwner {
+        WaitosaurState storage state = _getState();
+        if (state.lockedAmount > 0) revert ConfigCantBeUpdatedWhenLocked();
         WaitosaurObserverConfig storage config = _config();
         if (newOracle != address(0)) {
             config.oracle = newOracle;

--- a/src/WaitosaurObserver.sol
+++ b/src/WaitosaurObserver.sol
@@ -79,8 +79,7 @@ contract WaitosaurObserver is WaitosaurBase {
         address newOracle,
         string calldata newAsset
     ) external onlyOwner {
-        WaitosaurState storage state = _getState();
-        if (state.lockedAmount > 0) revert ConfigCantBeUpdatedWhenLocked();
+        if (!unlocked()) revert ConfigCantBeUpdatedWhenLocked();
         WaitosaurObserverConfig storage config = _config();
         if (newOracle != address(0)) {
             config.oracle = newOracle;

--- a/test/WaitosaurHolder.test.sol
+++ b/test/WaitosaurHolder.test.sol
@@ -5,7 +5,9 @@ import {Test} from "forge-std/Test.sol";
 
 import "../src/WaitosaurHolder.sol" as waitosaurSrc;
 import {WaitosaurBase, WaitosaurAccess} from "../src/WaitosaurBase.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 contract MockERC20 {
     string public name = "MockToken";
@@ -186,6 +188,17 @@ contract WaitosaurHolderTest is Test {
             })
         );
         waitosaur.updateConfig(newReceiver);
+    }
+
+    function testUpdateConfigRevertsWhenLocked() public {
+        vm.prank(locker);
+        waitosaur.lock(1 ether);
+
+        vm.prank(owner);
+        vm.expectRevert(
+            waitosaurSrc.WaitosaurHolder.ConfigCantBeUpdatedWhenLocked.selector
+        );
+        waitosaur.updateConfig(address(0x99));
     }
 
     function testNewConfigUsedForLockUnlock() public {

--- a/test/WaitosaurObserver.test.sol
+++ b/test/WaitosaurObserver.test.sol
@@ -2,10 +2,20 @@
 pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
-import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
-import {WaitosaurObserver, WaitosaurObserverConfig, IAumOracle} from "../src/WaitosaurObserver.sol";
-import {WaitosaurBase, WaitosaurState, WaitosaurAccess} from "../src/WaitosaurBase.sol";
+import {
+    WaitosaurObserver,
+    WaitosaurObserverConfig,
+    IAumOracle
+} from "../src/WaitosaurObserver.sol";
+import {
+    WaitosaurBase,
+    WaitosaurState,
+    WaitosaurAccess
+} from "../src/WaitosaurBase.sol";
 
 /// @notice Simple mock oracle returning a preset balance
 contract MockAumOracle is IAumOracle {
@@ -256,6 +266,17 @@ contract WaitosaurObserverTest is Test {
         WaitosaurObserverConfig memory cfg = observer.getConfig();
         assertEq(cfg.oracle, address(oracle));
         assertEq(cfg.asset, asset);
+    }
+
+    function testUpdateConfigRevertsWhenLocked() public {
+        vm.prank(locker);
+        observer.lock(1 ether);
+
+        vm.prank(owner);
+        vm.expectRevert(
+            WaitosaurObserver.ConfigCantBeUpdatedWhenLocked.selector
+        );
+        observer.updateConfig(address(0x12), "ETH");
     }
 
     // -------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces a new safeguard to both the `WaitosaurHolder` and `WaitosaurObserver` contracts, preventing configuration updates when tokens are locked. It also adds corresponding tests to ensure this behavior, and includes some minor import formatting changes for clarity