### PR TITLE
Permissionless reinitializer enables arbitrary core assignment and unlimited mint and burn

### DIFF
--- a/src/MaxBTCERC20.sol
+++ b/src/MaxBTCERC20.sol
@@ -74,7 +74,7 @@ contract MaxBTCERC20 is IMintableAndBurnable, UUPSUpgradeable, ERC20Upgradeable,
     }
 
     /// @notice Migrates the MaxBTCERC20 contract to V2
-    /// @param core_ The Core contract address
+    /// @param core_ The Core contract address (zero address means core is not set)
     function initializeV2(address core_) external reinitializer(2) onlyOwner {
         __Ownable2Step_init();
         StorageSlot.getAddressSlot(CORE_STORAGE_SLOT).value = core_;
@@ -154,7 +154,7 @@ contract MaxBTCERC20 is IMintableAndBurnable, UUPSUpgradeable, ERC20Upgradeable,
     }
 
     /// @notice Allows token owner to update Core
-    /// @param core_ The Core contract address
+    /// @param core_ The Core contract address (zero address means core is not set)
     function updateCore(address core_) external onlyOwner {
         StorageSlot.getAddressSlot(CORE_STORAGE_SLOT).value = core_;
         emit CoreUpdated(_msgSender(), core_);

--- a/src/MaxBTCERC20.sol
+++ b/src/MaxBTCERC20.sol
@@ -18,6 +18,8 @@ contract MaxBTCERC20 is IMintableAndBurnable, UUPSUpgradeable, ERC20Upgradeable,
     /// @param limit Allowed amount of tokens to burn/mint
     error EurekaRateLimitsExceeded(uint256 requested, uint256 limit);
 
+    error InvalidCoreAddress();
+
     event CoreUpdated(address updater, address core);
     event Ics20Updated(address updater, address ics20);
     event EurekaRateLimitsUpdated(address updater, uint256 inbound, uint256 outbound);
@@ -75,8 +77,11 @@ contract MaxBTCERC20 is IMintableAndBurnable, UUPSUpgradeable, ERC20Upgradeable,
 
     /// @notice Migrates the MaxBTCERC20 contract to V2
     /// @param core_ The Core contract address
-    function initializeV2(address core_) external reinitializer(2) {
+    function initializeV2(address core_) external reinitializer(2) onlyOwner {
         __Ownable2Step_init();
+        if (core_ == address(0)) {
+            revert InvalidCoreAddress();
+        }
         StorageSlot.getAddressSlot(CORE_STORAGE_SLOT).value = core_;
     }
 
@@ -150,6 +155,9 @@ contract MaxBTCERC20 is IMintableAndBurnable, UUPSUpgradeable, ERC20Upgradeable,
     /// @notice Allows token owner to update Core
     /// @param core_ The Core contract address
     function updateCore(address core_) external onlyOwner {
+        if (core_ == address(0)) {
+            revert InvalidCoreAddress();
+        }
         StorageSlot.getAddressSlot(CORE_STORAGE_SLOT).value = core_;
         emit CoreUpdated(_msgSender(), core_);
     }

--- a/src/MaxBTCERC20.sol
+++ b/src/MaxBTCERC20.sol
@@ -18,8 +18,6 @@ contract MaxBTCERC20 is IMintableAndBurnable, UUPSUpgradeable, ERC20Upgradeable,
     /// @param limit Allowed amount of tokens to burn/mint
     error EurekaRateLimitsExceeded(uint256 requested, uint256 limit);
 
-    error InvalidCoreAddress();
-
     event CoreUpdated(address updater, address core);
     event Ics20Updated(address updater, address ics20);
     event EurekaRateLimitsUpdated(address updater, uint256 inbound, uint256 outbound);
@@ -79,9 +77,6 @@ contract MaxBTCERC20 is IMintableAndBurnable, UUPSUpgradeable, ERC20Upgradeable,
     /// @param core_ The Core contract address
     function initializeV2(address core_) external reinitializer(2) onlyOwner {
         __Ownable2Step_init();
-        if (core_ == address(0)) {
-            revert InvalidCoreAddress();
-        }
         StorageSlot.getAddressSlot(CORE_STORAGE_SLOT).value = core_;
     }
 
@@ -119,8 +114,11 @@ contract MaxBTCERC20 is IMintableAndBurnable, UUPSUpgradeable, ERC20Upgradeable,
             }
 
             rateLimits.inbound -= amount;
-        } else if (_msgSender() != core()) {
-            revert CallerIsNotAllowed(_msgSender());
+        } else {
+            address _core = core();
+            if (_core == address(0) || _core != _msgSender()) {
+                revert CallerIsNotAllowed(_msgSender());
+            }
         }
 
         _mint(mintAddress, amount);
@@ -135,8 +133,11 @@ contract MaxBTCERC20 is IMintableAndBurnable, UUPSUpgradeable, ERC20Upgradeable,
             }
 
             rateLimits.outbound -= amount;
-        } else if (_msgSender() != core()) {
-            revert CallerIsNotAllowed(_msgSender());
+        } else {
+            address _core = core();
+            if (_core == address(0) || _core != _msgSender()) {
+                revert CallerIsNotAllowed(_msgSender());
+            }
         }
 
         _burn(mintAddress, amount);
@@ -155,9 +156,6 @@ contract MaxBTCERC20 is IMintableAndBurnable, UUPSUpgradeable, ERC20Upgradeable,
     /// @notice Allows token owner to update Core
     /// @param core_ The Core contract address
     function updateCore(address core_) external onlyOwner {
-        if (core_ == address(0)) {
-            revert InvalidCoreAddress();
-        }
         StorageSlot.getAddressSlot(CORE_STORAGE_SLOT).value = core_;
         emit CoreUpdated(_msgSender(), core_);
     }

--- a/test/MaxBTCERC20.test.sol
+++ b/test/MaxBTCERC20.test.sol
@@ -19,6 +19,7 @@ contract MaxBTCERC20Test is Test {
             abi.encodeCall(MaxBTCERC20.initialize, (OWNER, ICS20, "Structured maxBTC", "maxBTC"));
         ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), maxBTCERC20InitializeCall);
         maxBtcErc20 = MaxBTCERC20(address(proxy));
+        vm.prank(OWNER);
         maxBtcErc20.initializeV2(CORE);
     }
 

--- a/test/MaxBTCERC20.test.sol
+++ b/test/MaxBTCERC20.test.sol
@@ -29,8 +29,26 @@ contract MaxBTCERC20Test is Test {
         assertEq(maxBtcErc20.balanceOf(ESCROW), 100);
     }
 
+    function testMintSuccessWithCoreUnset() external {
+        vm.startPrank(OWNER);
+        maxBtcErc20.updateCore(address(0));
+        maxBtcErc20.setEurekaRateLimits(100, 0);
+
+        vm.startPrank(ICS20);
+        maxBtcErc20.mint(ESCROW, 100);
+        assertEq(maxBtcErc20.balanceOf(ESCROW), 100);
+    }
+
     function testMintUnauthorized() external {
         vm.startPrank(OWNER);
+        vm.expectRevert(abi.encodeWithSelector(MaxBTCERC20.CallerIsNotAllowed.selector, OWNER));
+        maxBtcErc20.mint(ESCROW, 100);
+    }
+
+    function testMintUnauthorizedWithCoreUnset() external {
+        vm.startPrank(OWNER);
+        maxBtcErc20.updateCore(address(0));
+
         vm.expectRevert(abi.encodeWithSelector(MaxBTCERC20.CallerIsNotAllowed.selector, OWNER));
         maxBtcErc20.mint(ESCROW, 100);
     }
@@ -42,10 +60,29 @@ contract MaxBTCERC20Test is Test {
         assertEq(maxBtcErc20.balanceOf(ESCROW), 80);
     }
 
+    function testBurnSuccessWithCoreUnset() external {
+        vm.startPrank(OWNER);
+        maxBtcErc20.updateCore(address(0));
+        maxBtcErc20.setEurekaRateLimits(100, 20);
+
+        vm.startPrank(ICS20);
+        maxBtcErc20.mint(ESCROW, 100);
+        maxBtcErc20.burn(ESCROW, 20);
+        assertEq(maxBtcErc20.balanceOf(ESCROW), 80);
+    }
+
     function testBurnUnauthorized() external {
         vm.startPrank(CORE);
         maxBtcErc20.mint(ESCROW, 100);
         vm.startPrank(OWNER);
+        vm.expectRevert(abi.encodeWithSelector(MaxBTCERC20.CallerIsNotAllowed.selector, OWNER));
+        maxBtcErc20.burn(ESCROW, 20);
+    }
+
+    function testBurnUnauthorizedWithCoreUnset() external {
+        vm.startPrank(OWNER);
+        maxBtcErc20.updateCore(address(0));
+
         vm.expectRevert(abi.encodeWithSelector(MaxBTCERC20.CallerIsNotAllowed.selector, OWNER));
         maxBtcErc20.burn(ESCROW, 20);
     }


### PR DESCRIPTION
### Description

In maxbtc-evm:src/MaxBTCERC20.sol:94–99, the initializeV2 function is
declared as external reinitializer(2) and lacks any access control. This allows any
address to call it once before the legitimate V2 initialization occurs and set
CORE_STORAGE_SLOT to an arbitrary core_ address. Because the function directly writes to
storage using StorageSlot.getAddressSlot(CORE_STORAGE_SLOT).value =core_, an attacker can assign themselves as the core contract.
In MaxBTCERC20, the mint and burn functions grant unrestricted privileges to the core
a ddress, bypassing ICS20 rate limits. As a result, a malicious actor can front-run the intended
initialization, set core to themselves, and immediately mint or burn tokens arbitrarily.
Although the owner can later call updateCore (lines 172–177) to correct the value, this
does not mitigate the attack, since the attacker can exploit the privileges immediately after
calling initializeV2, before the owner notices and intervenes.
This results in a privilege escalation enabling unlimited token minting and burning.

### Recommendation
We recommend restricting initializeV2 so only a trusted party can execute it, for
example, by adding onlyOwner or by requiring the caller to be the current owner, and
validating core_
is non-zero. If the intention is that upgrades always call
upgradeToAndCall with initializeV2 atomically, it is still safer to enforce authorization
on initializeV2 to prevent a front-run or missed initialization.