### PR TITLE
fix: update deploy script to use deployer address

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,19 @@ Run `bun install` to obtain dependencies. Then, run `forge build` to make sure c
 
 Then, run `source .env`.
 
+Note: the deploy scripts use an explicit `DEPLOYER_PRIVATE_KEY` environment variable; set it before running the scripts. The scripts will print the deployer address.
+
 ### Step 2. Deploy MaxBTCERC20 implementation contract
 
-This contract will store vault source code and act behind a proxy, hence it is easy to deploy it. Simply run `forge script script/DeployMaxBTCERC20Implementation.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv` and write down the final contract address, you will need it in the next step.
+This contract will store vault source code and act behind a proxy. For example:
+
+```
+DEPLOYER_PRIVATE_KEY=0xYOUR_PRIVATE_KEY forge script script/DeployMaxBTCERC20Implementation.script.sol --rpc-url "$ETHEREUM_RPC_URL" --broadcast --verify -vvvv
+```
 
 ### Step 3. Deploy MaxBTCERC20
 
-Run `OWNER="" IMPLEMENTATION="" ICS20="" TOKEN_NAME="" TOKEN_SYMBOL="" forge script script/DeployMaxBTCERC20.script.sol --rpc-url "$ETHEREUM_RPC_URL" --private-key "$ETHEREUM_PRIVATE_KEY" --broadcast --verify -vvvv`, where:
+Run `OWNER="" IMPLEMENTATION="" ICS20="" TOKEN_NAME="" TOKEN_SYMBOL="" DEPLOYER_PRIVATE_KEY=0xYOUR_PRIVATE_KEY forge script script/DeployMaxBTCERC20.script.sol --rpc-url "$ETHEREUM_RPC_URL" --broadcast --verify -vvvv`, where:
 - `OWNER` must be set to account address, which will become a `MaxBTCERC20` admin;
 - `IMPLEMENTATION` must be set to the contract address, obtained in step 2;
 - `ICS20` must be set to the `ICS20Transfer` contract address (`0xa348CfE719B63151F228e3C30EB424BA5a983012` on Ethereum Mainnet);

--- a/script/DeployMaxBTCERC20.script.sol
+++ b/script/DeployMaxBTCERC20.script.sol
@@ -16,7 +16,10 @@ contract DeployMaxBTCERC20 is Script {
 
         bytes memory initializeCall = abi.encodeCall(MaxBTCERC20.initialize, (owner, ics20, name, symbol));
 
-        vm.startBroadcast();
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerKey);
+        console.log("Using deployer address:", deployer);
+        vm.startBroadcast(deployerKey);
         ERC1967Proxy proxy = new ERC1967Proxy(implementation, initializeCall);
         vm.stopBroadcast();
 

--- a/script/DeployMaxBTCERC20Implementation.script.sol
+++ b/script/DeployMaxBTCERC20Implementation.script.sol
@@ -7,7 +7,10 @@ import { MaxBTCERC20 } from "../src/MaxBTCERC20.sol";
 
 contract DeployMaxBTCERC20Implementation is Script {
     function run() external {
-        vm.startBroadcast();
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerKey);
+        console.log("Using deployer address:", deployer);
+        vm.startBroadcast(deployerKey);
         MaxBTCERC20 maxBTCERC20 = new MaxBTCERC20();
         vm.stopBroadcast();
 

--- a/script/DeployMaxBTCERC20V2.script.sol
+++ b/script/DeployMaxBTCERC20V2.script.sol
@@ -15,7 +15,10 @@ contract DeployMaxBTCERC20 is Script {
 
         MaxBTCERC20 maxBTC = MaxBTCERC20(proxy);
 
-        vm.startBroadcast();
+        uint256 deployerKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerKey);
+        console.log("Using deployer address:", deployer);
+        vm.startBroadcast(deployerKey);
         maxBTC.upgradeToAndCall(newImplementation, initializeV2Call);
         vm.stopBroadcast();
 


### PR DESCRIPTION
In maxbtc-evm:contracts/maxbtc-evm/script/DeployMaxBTCERC20.script.so
l:10-21, the DeployMaxBTCERC20 script calls vm.startBroadcast without specifying
a deployer key or address.
Foundry will then use the default broadcaster configured for the environment, so if the
operator’s Foundry config is misconfigured the deployment transaction can be sent from an
unintended account.

**Recommendation** 
We recommend passing the deployer address explicitly to vm.startBroadcast, so
deployments cannot accidentally be broadcast from an unintended account. Also consider
logging the broadcaster address in the script for easier verification.