### PR TITLE
feat: more options in withdrawal manager's `updateConfig()`

### DIFF
--- a/src/WithdrawalManager.sol
+++ b/src/WithdrawalManager.sol
@@ -144,12 +144,32 @@ contract WithdrawalManager is Initializable, UUPSUpgradeable, ERC1155HolderUpgra
         revert BatchSupportNotEnabled();
     }
 
-    function updateConfig(address newAllowlistContract) external onlyOwner {
+    function updateConfig(
+        address newCoreContract,
+        address newWithdrawalTokenContract,
+        address newAllowlistContract
+    )
+        external
+        onlyOwner
+    {
         WithdrawalManagerConfig storage config = _getWithdrawalManagerConfig();
+
+        if (newCoreContract == address(0)) {
+            revert InvalidCoreContractAddress();
+        }
+        if (newWithdrawalTokenContract == address(0)) {
+            revert InvalidWithdrawalTokenContractAddress();
+        }
         if (newAllowlistContract == address(0)) {
             revert InvalidAllowlistContractAddress();
         }
+
+        config.coreContract = newCoreContract;
+        config.withdrawalTokenContract = newWithdrawalTokenContract;
         config.allowlistContract = newAllowlistContract;
+
+        emit ConfigSettingUpdated("coreContract", newCoreContract);
+        emit ConfigSettingUpdated("withdrawalToken", newWithdrawalTokenContract);
         emit ConfigSettingUpdated("allowlistContract", newAllowlistContract);
     }
 

--- a/test/WithdrawalManager.test.sol
+++ b/test/WithdrawalManager.test.sol
@@ -251,27 +251,37 @@ contract WithdrawalManagerTest is Test {
 
     function testUpdateConfigByOwner() public {
         // Owner updates config successfully
-        address newAllowlist = address(0x4444);
+        address newCore = address(0x4444);
+        address newWithdrawalToken = address(0x5555);
+        address newAllowlist = address(0x6666);
 
         vm.prank(owner);
-        manager.updateConfig(newAllowlist);
+        manager.updateConfig(newCore, newWithdrawalToken, newAllowlist);
 
         WithdrawalManager.WithdrawalManagerConfig memory config = manager.getConfig();
 
+        assertEq(config.coreContract, newCore);
+        assertEq(config.withdrawalTokenContract, newWithdrawalToken);
         assertEq(config.allowlistContract, newAllowlist);
     }
 
     function testUpdateConfigRevertsForNonOwner() public {
         // Non-owner must not be able to update config
         vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", address(this)));
-        manager.updateConfig(address(4));
+        manager.updateConfig(address(4), address(5), address(6));
     }
 
     function testUpdateConfigRevertsForZeroAddresses() public {
         // Zero addresses are forbidden
-        vm.prank(owner);
+        vm.startPrank(owner);
+        vm.expectRevert(abi.encodeWithSelector(WithdrawalManager.InvalidCoreContractAddress.selector));
+        manager.updateConfig(address(0), address(1), address(1));
+
+        vm.expectRevert(abi.encodeWithSelector(WithdrawalManager.InvalidWithdrawalTokenContractAddress.selector));
+        manager.updateConfig(address(1), address(0), address(1));
+
         vm.expectRevert(abi.encodeWithSelector(WithdrawalManager.InvalidAllowlistContractAddress.selector));
-        manager.updateConfig(address(0));
+        manager.updateConfig(address(1), address(1), address(0));
     }
 
     function testPauseAndUnpauseEmitsEventsAndChangesState() public {


### PR DESCRIPTION
This PR allows us to update core and withdrawal token in withdrawal manager's config.

#### Why is this PR a DONTMERGE draft?

I would like to merge it in a following flow:
- [ ] finish audit
- [ ] merge audit branch to main
- [ ] retarget this PR to main
- [ ] undraft this PR
- [ ] merge this PR